### PR TITLE
:art: Support tool-result + slight changes in preparation for claude streaming support

### DIFF
--- a/cmd/overlay/main.go
+++ b/cmd/overlay/main.go
@@ -69,9 +69,9 @@ var (
 		BorderForeground(highlight).
 		Padding(0, 1)
 
-	activeTab = tab.Copy().Border(activeTabBorder, true)
+	activeTab = tab.Border(activeTabBorder, true)
 
-	tabGap = tab.Copy().
+	tabGap = tab.
 		BorderTop(false).
 		BorderLeft(false).
 		BorderRight(false)
@@ -110,7 +110,7 @@ var (
 			Padding(0, 3).
 			MarginTop(1)
 
-	activeButtonStyle = buttonStyle.Copy().
+	activeButtonStyle = buttonStyle.
 				Foreground(lipgloss.Color("#FFF7DB")).
 				Background(lipgloss.Color("#F25D94")).
 				MarginRight(2).
@@ -174,13 +174,13 @@ var (
 			Padding(0, 1).
 			MarginRight(1)
 
-	encodingStyle = statusNugget.Copy().
+	encodingStyle = statusNugget.
 			Background(lipgloss.Color("#A550DF")).
 			Align(lipgloss.Right)
 
 	statusText = lipgloss.NewStyle().Inherit(statusBarStyle)
 
-	fishCakeStyle = statusNugget.Copy().Background(lipgloss.Color("#6124DF"))
+	fishCakeStyle = statusNugget.Background(lipgloss.Color("#6124DF"))
 
 	// Page.
 
@@ -223,7 +223,7 @@ func main() {
 		for i, v := range colors {
 			const offset = 2
 			c := lipgloss.Color(v[0])
-			_, _ = fmt.Fprint(&title, titleStyle.Copy().MarginLeft(i*offset).Background(c))
+			_, _ = fmt.Fprint(&title, titleStyle.MarginLeft(i*offset).Background(c))
 			if i < len(colors)-1 {
 				title.WriteRune('\n')
 			}
@@ -289,7 +289,7 @@ func main() {
 				listItem("Pomelo"),
 			),
 		),
-		list.Copy().Width(columnWidth).Render(
+		list.Width(columnWidth).Render(
 			lipgloss.JoinVertical(lipgloss.Left,
 				listHeader("Actual Lip Gloss Vendors"),
 				listItem("Glossier"),
@@ -313,9 +313,9 @@ func main() {
 
 		doc.WriteString(lipgloss.JoinHorizontal(
 			lipgloss.Top,
-			historyStyle.Copy().Align(lipgloss.Right).Render(historyA),
-			historyStyle.Copy().Align(lipgloss.Center).Render(historyB),
-			historyStyle.Copy().MarginRight(0).Render(historyC),
+			historyStyle.Align(lipgloss.Right).Render(historyA),
+			historyStyle.Align(lipgloss.Center).Render(historyB),
+			historyStyle.MarginRight(0).Render(historyC),
 		))
 
 		doc.WriteString("\n\n")
@@ -328,7 +328,7 @@ func main() {
 		statusKey := statusStyle.Render("STATUS")
 		encoding := encodingStyle.Render("UTF-8")
 		fishCake := fishCakeStyle.Render("🍥 Fish Cake")
-		statusVal := statusText.Copy().
+		statusVal := statusText.
 			Width(width - w(statusKey) - w(encoding) - w(fishCake)).
 			Render("Ravishing")
 

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/charmbracelet/bubbletea v0.25.0
 	github.com/charmbracelet/lipgloss v0.10.0
 	github.com/dustin/go-humanize v1.0.1
-	github.com/go-go-golems/glazed v0.5.4
+	github.com/go-go-golems/glazed v0.5.17
 	github.com/google/uuid v1.6.0
 	github.com/lucasb-eyer/go-colorful v1.2.0
 	github.com/mattn/go-runewidth v0.0.15

--- a/go.sum
+++ b/go.sum
@@ -23,8 +23,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
-github.com/go-go-golems/glazed v0.5.4 h1:zDKpixOKQA5LBQQAKTWgZlqYGN+hnRHSkbNo0aKF1Ko=
-github.com/go-go-golems/glazed v0.5.4/go.mod h1:K1600pUk7xB/LKmvIafRWyfAdxE1sboruqQ9Jia8V9M=
+github.com/go-go-golems/glazed v0.5.17 h1:rqkSPGClE2i0wgq/Bo4+dWK0polGITioCs494sWp3+Y=
+github.com/go-go-golems/glazed v0.5.17/go.mod h1:C1zWpbRfs3+xmtAZoW6RFgFvTLeC2xq+gkc1S5Luvz4=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/huandu/xstrings v1.4.0 h1:D17IlohoQq4UcpqD7fDk80P7l+lwAmlFaBHgOipl2FU=

--- a/pkg/buttons/buttons.go
+++ b/pkg/buttons/buttons.go
@@ -86,7 +86,7 @@ var (
 			Padding(0, 3).
 			Margin(0, 1)
 
-	activeButtonStyle = buttonStyle.Copy().
+	activeButtonStyle = buttonStyle.
 				Foreground(lipgloss.Color("#FFF7DB")).
 				Background(lipgloss.Color("#F25D94")).
 				Underline(true)

--- a/pkg/conversation/message.go
+++ b/pkg/conversation/message.go
@@ -10,6 +10,7 @@ import (
 
 type ContentType string
 
+// TODO(manuel, 2024-07-04) Unify this with the events types that we added for the claude API
 const (
 	ContentTypeChatMessage ContentType = "chat-message"
 	// TODO(manuel, 2024-06-04) This needs to also handle tool call and tool response blocks (tool use block in claude API)
@@ -80,8 +81,8 @@ func (t *ToolUseContent) View() string {
 var _ MessageContent = (*ToolUseContent)(nil)
 
 type ToolResultContent struct {
-	ToolID string          `json:"toolID"`
-	Result json.RawMessage `json:"result"`
+	ToolID string `json:"toolID"`
+	Result string `json:"result"`
 }
 
 func (t *ToolResultContent) ContentType() ContentType {

--- a/pkg/conversation/message.go
+++ b/pkg/conversation/message.go
@@ -31,6 +31,7 @@ const (
 	RoleSystem    Role = "system"
 	RoleAssistant Role = "assistant"
 	RoleUser      Role = "user"
+	RoleTool      Role = "tool"
 )
 
 type ChatMessageContent struct {
@@ -60,6 +61,8 @@ type ToolUseContent struct {
 	ToolID string          `json:"toolID"`
 	Name   string          `json:"name"`
 	Input  json.RawMessage `json:"input"`
+	// used by openai currently (only function)
+	Type string `json:"type"`
 }
 
 func (t *ToolUseContent) ContentType() ContentType {
@@ -67,11 +70,11 @@ func (t *ToolUseContent) ContentType() ContentType {
 }
 
 func (t *ToolUseContent) String() string {
-	return fmt.Sprintf("ToolUseContent{ToolID: %s, Name: %s, Result}, %s", t.ToolID, t.Name, t.Input)
+	return fmt.Sprintf("ToolUseContent{ToolID: %s, Name: %s, Input: %s}", t.ToolID, t.Name, t.Input)
 }
 
 func (t *ToolUseContent) View() string {
-	return fmt.Sprintf("ToolUseContent{ToolID: %s, Name: %s, Result}, %s", t.ToolID, t.Name, t.Input)
+	return fmt.Sprintf("ToolUseContent{ToolID: %s, Name: %s, Input: %s}", t.ToolID, t.Name, t.Input)
 }
 
 var _ MessageContent = (*ToolUseContent)(nil)
@@ -86,11 +89,11 @@ func (t *ToolResultContent) ContentType() ContentType {
 }
 
 func (t *ToolResultContent) String() string {
-	return fmt.Sprintf("ToolResultContent{ToolID: %s, Result}, %s", t.ToolID, t.Result)
+	return fmt.Sprintf("ToolResultContent{ToolID: %s, Result: %s}", t.ToolID, t.Result)
 }
 
 func (t *ToolResultContent) View() string {
-	return fmt.Sprintf("ToolResultContent{ToolID: %s, Result}, %s", t.ToolID, t.Result)
+	return fmt.Sprintf("ToolResultContent{ToolID: %s, Result: %s}", t.ToolID, t.Result)
 }
 
 var _ MessageContent = (*ToolResultContent)(nil)

--- a/pkg/conversation/tree.go
+++ b/pkg/conversation/tree.go
@@ -26,6 +26,10 @@ func (id *NodeID) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (id NodeID) String() string {
+	return uuid.UUID(id).String()
+}
+
 func NewNodeID() NodeID {
 	return NodeID(uuid.New())
 }


### PR DESCRIPTION
This pull request includes several minor changes to prepare for Claude streaming:

  - Removed unnecessary `Copy()` calls on styles.

- **Enhance Tool Use Content**:
  - Added `RoleTool` to the `Role` type.
  - Fixed string representations of `ToolUseContent` and `ToolResultContent`.

  - Implemented `String()` method for `NodeID` to improve debugging and logging.

- **TODOs for Future Improvements**:
  - Added TODO comments for unifying content types with Claude API events.
  - Added TODO comments for handling tool call and response blocks.


