### PR TITLE
Add support for image content in conversations

### DIFF
--- a/pkg/conversation/tree.go
+++ b/pkg/conversation/tree.go
@@ -70,6 +70,12 @@ func (mn *Message) UnmarshalJSON(data []byte) error {
 			return err
 		}
 		mn.Content = content
+	case ContentTypeImage:
+		var content *ImageContent
+		if err := json.Unmarshal(mna.Content, &content); err != nil {
+			return err
+		}
+		mn.Content = content
 	default:
 		return errors.New("unknown content type")
 	}


### PR DESCRIPTION
Implement image support for Claude conversations:

- New ContentTypeImage constant for image content
- ImageContent struct to handle image data:
  • Supports URL and local file paths
  • Validates file size (max 20MB)
  • Handles common image formats (PNG, JPEG, WebP, GIF)
- ChatMessageContent now includes an Images field
- ImageDetail enum for specifying image quality (low, high, auto)
- Helper functions for creating ImageContent from files or URLs
- JSON unmarshaling support for image content in conversation tree

Next steps:
- Implement image handling in the conversation flow
- Add UI support for displaying images
