### PR TITLE
Add auto-start option and clean up header display

### DIFF
--- a/pkg/chat/model.go
+++ b/pkg/chat/model.go
@@ -356,7 +356,7 @@ func (m *model) recomputeSize() {
 }
 
 func (m model) headerView() string {
-	return m.title
+	return ""
 }
 
 func (m model) textAreaView() string {
@@ -401,7 +401,7 @@ func (m model) View() string {
 
 	ret := ""
 	if headerView != "" {
-		ret = headerView + "\n" + helpView
+		ret = headerView
 	}
 
 	switch m.state {

--- a/pkg/chat/model.go
+++ b/pkg/chat/model.go
@@ -48,6 +48,7 @@ type Status struct {
 
 type model struct {
 	conversationManager geppetto_conversation.Manager
+	autoStartBackend    bool
 
 	viewport       viewport.Model
 	scrollToBottom bool
@@ -90,6 +91,12 @@ func WithTitle(title string) ModelOption {
 func WithStatus(status *Status) ModelOption {
 	return func(m *model) {
 		m.status = status
+	}
+}
+
+func WithAutoStartBackend(autoStartBackend bool) ModelOption {
+	return func(m *model) {
+		m.autoStartBackend = autoStartBackend
 	}
 }
 
@@ -151,9 +158,11 @@ func (m model) Init() tea.Cmd {
 
 	m.updateKeyBindings()
 
-	cmds = append(cmds, func() tea.Msg {
-		return StartBackendMsg{}
-	})
+	if m.autoStartBackend {
+		cmds = append(cmds, func() tea.Msg {
+			return StartBackendMsg{}
+		})
+	}
 
 	return tea.Batch(cmds...)
 }

--- a/pkg/chat/user_messages.go
+++ b/pkg/chat/user_messages.go
@@ -24,6 +24,7 @@ type FocusMessageMsg struct{}
 type SelectNextMessageMsg struct{}
 type SelectPrevMessageMsg struct{}
 type SubmitMessageMsg struct{}
+type StartBackendMsg struct{}
 type CopyToClipboardMsg struct{}
 type CopyLastResponseToClipboardMsg struct{}
 type CopyLastSourceBlocksToClipboardMsg struct{}


### PR DESCRIPTION
Adds ability to automatically start the backend when initializing the chat model and
cleans up header display.

Changes:
* Add `WithAutoStartBackend` option for model initialization
* Remove title and help text from header view

