### PR TITLE
Improve error handling and message rendering

### DIFF
--- a/cmd/chat/main.go
+++ b/cmd/chat/main.go
@@ -74,7 +74,10 @@ func runChat(backendFactory func() chat.Backend) {
 		tea.WithAltScreen(),
 	}
 
-	p := tea.NewProgram(chat.InitialModel(manager, backend, chat.WithStatus(status)), options...)
+	p := tea.NewProgram(
+		chat.InitialModel(manager, backend, chat.WithStatus(status)),
+		options...,
+	)
 
 	// Set up the HTTP server
 	r := mux.NewRouter()

--- a/go.mod
+++ b/go.mod
@@ -9,8 +9,8 @@ require (
 	github.com/charmbracelet/glamour v0.9.1
 	github.com/charmbracelet/lipgloss v1.1.0
 	github.com/dustin/go-humanize v1.0.1
-	github.com/go-go-golems/geppetto v0.4.47
-	github.com/go-go-golems/glazed v0.5.44
+	github.com/go-go-golems/geppetto v0.4.48
+	github.com/go-go-golems/glazed v0.5.47
 	github.com/google/uuid v1.6.0
 	github.com/lucasb-eyer/go-colorful v1.2.0
 	github.com/mattn/go-runewidth v0.0.16

--- a/go.sum
+++ b/go.sum
@@ -57,10 +57,10 @@ github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkp
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f h1:Y/CXytFA4m6baUTXGLOoWe4PQhGxaX0KpnayAqC48p4=
 github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f/go.mod h1:vw97MGsxSvLiUE2X8qFplwetxpGLQrlU1Q9AUEIzCaM=
-github.com/go-go-golems/geppetto v0.4.47 h1:+JGLUZJZEzGfb+MiGcceVv6y5Ye6P3/E/8nYp4Hi4PU=
-github.com/go-go-golems/geppetto v0.4.47/go.mod h1:Nlid0zl6WqEeUdO8SY9mIxOpXQD1x+BfuG6cUBsC6d4=
-github.com/go-go-golems/glazed v0.5.44 h1:qsFKlD9mH5B5LWkx/CyltHC0eGFsZI0NDzImSusC4+E=
-github.com/go-go-golems/glazed v0.5.44/go.mod h1:9BLzfCpwtvcf+JESxhT3QBCAPt2H2Yk3NDi0FBhCwQw=
+github.com/go-go-golems/geppetto v0.4.48 h1:hQUMOSDhCB56JjVPM19U1NI6NVfMMv5NxmVw3iqXv6I=
+github.com/go-go-golems/geppetto v0.4.48/go.mod h1:dH9wOY9uhLeZDmK2ltT+/aozWrhFoMKiDJdJFgXyrkE=
+github.com/go-go-golems/glazed v0.5.47 h1:e6nXWO4/j/odHfyp65A+KOGVE3U6ooLE6fbElxn1DrU=
+github.com/go-go-golems/glazed v0.5.47/go.mod h1:9BLzfCpwtvcf+JESxhT3QBCAPt2H2Yk3NDi0FBhCwQw=
 github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/google/uuid v1.2.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=

--- a/pkg/chat/model.go
+++ b/pkg/chat/model.go
@@ -21,7 +21,7 @@ import (
 	"github.com/pkg/errors"
 )
 
-type errMsg error
+type ErrorMsg error
 
 type State string
 
@@ -221,7 +221,7 @@ func (m model) saveToFile(path string) (tea.Model, tea.Cmd) {
 	err := m.conversationManager.SaveToFile(path)
 	if err != nil {
 		return m, func() tea.Msg {
-			return errMsg(err)
+			return ErrorMsg(err)
 		}
 	}
 
@@ -247,7 +247,7 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.recomputeSize()
 
 	// We handle errors just like any other message
-	case errMsg:
+	case ErrorMsg:
 		m.err = msg_
 		return m, nil
 
@@ -447,7 +447,7 @@ func (m *model) startBackend() tea.Cmd {
 			ctx := context2.Background()
 			cmd, err := m.backend.Start(ctx, m.conversationManager.GetConversation())
 			if err != nil {
-				return errMsg(err)
+				return ErrorMsg(err)
 			}
 			return cmd()
 		},
@@ -457,7 +457,7 @@ func (m *model) startBackend() tea.Cmd {
 func (m *model) submit() tea.Cmd {
 	if !m.backend.IsFinished() {
 		return func() tea.Msg {
-			return errMsg(errors.New("already streaming"))
+			return ErrorMsg(errors.New("already streaming"))
 		}
 	}
 
@@ -577,7 +577,7 @@ func (m model) handleUserAction(msg UserActionMsg) (tea.Model, tea.Cmd) {
 					err := clipboard.WriteAll(msg_.Content.String())
 					if err != nil {
 						cmd = func() tea.Msg {
-							return errMsg(err)
+							return ErrorMsg(err)
 						}
 					}
 				}
@@ -593,7 +593,7 @@ func (m model) handleUserAction(msg UserActionMsg) (tea.Model, tea.Cmd) {
 				err := clipboard.WriteAll(text)
 				if err != nil {
 					cmd = func() tea.Msg {
-						return errMsg(err)
+						return ErrorMsg(err)
 					}
 				}
 			}
@@ -610,7 +610,7 @@ func (m model) handleUserAction(msg UserActionMsg) (tea.Model, tea.Cmd) {
 						err := clipboard.WriteAll(content.Text)
 						if err != nil {
 							cmd = func() tea.Msg {
-								return errMsg(err)
+								return ErrorMsg(err)
 							}
 						}
 					}
@@ -622,7 +622,7 @@ func (m model) handleUserAction(msg UserActionMsg) (tea.Model, tea.Cmd) {
 						err := clipboard.WriteAll(content.Text)
 						if err != nil {
 							cmd = func() tea.Msg {
-								return errMsg(err)
+								return ErrorMsg(err)
 							}
 						}
 					}
@@ -642,7 +642,7 @@ func (m model) handleUserAction(msg UserActionMsg) (tea.Model, tea.Cmd) {
 						err := clipboard.WriteAll(strings.Join(code, "\n"))
 						if err != nil {
 							cmd = func() tea.Msg {
-								return errMsg(err)
+								return ErrorMsg(err)
 							}
 						}
 					}
@@ -661,7 +661,7 @@ func (m model) handleUserAction(msg UserActionMsg) (tea.Model, tea.Cmd) {
 					err := clipboard.WriteAll(strings.Join(code, "\n"))
 					if err != nil {
 						cmd = func() tea.Msg {
-							return errMsg(err)
+							return ErrorMsg(err)
 						}
 					}
 				}
@@ -680,7 +680,7 @@ func (m model) handleUserAction(msg UserActionMsg) (tea.Model, tea.Cmd) {
 						err := clipboard.WriteAll(strings.Join(code, "\n"))
 						if err != nil {
 							cmd = func() tea.Msg {
-								return errMsg(err)
+								return ErrorMsg(err)
 							}
 						}
 					}
@@ -698,7 +698,7 @@ func (m model) handleUserAction(msg UserActionMsg) (tea.Model, tea.Cmd) {
 				err := clipboard.WriteAll(strings.Join(code, "\n"))
 				if err != nil {
 					cmd = func() tea.Msg {
-						return errMsg(err)
+						return ErrorMsg(err)
 					}
 				}
 			}


### PR DESCRIPTION
This PR enhances error handling and message presentation in the chat interface:

* Display error messages directly in the chat UI instead of just logging them
* Properly format error messages with markdown styling
* Include error metadata in message objects
* Rename `errMsg` to `ErrorMsg`
* Fix markdown rendering by ensuring newline at end of content
* Update dependencies to latest versions of geppetto and glazed

These changes provide better visibility into errors that occur during LLM 
interactions, making it easier to diagnose issues without needing to check logs.