### PR TITLE
Rewrite repl to use the timeline

### DIFF
--- a/cmd/repl-timeline-demo/main.go
+++ b/cmd/repl-timeline-demo/main.go
@@ -1,23 +1,23 @@
 package main
 
 import (
-    "context"
-    "flag"
-    "fmt"
-    "log"
-    "io"
-    "os"
-    "os/exec"
-    "sync"
-    "strings"
-    "time"
+	"context"
+	"flag"
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"os/exec"
+	"strings"
+	"sync"
+	"time"
 
-    tea "github.com/charmbracelet/bubbletea"
-    "github.com/go-go-golems/bobatea/pkg/eventbus"
-    "github.com/go-go-golems/bobatea/pkg/repl"
-    "github.com/go-go-golems/bobatea/pkg/timeline"
-    "github.com/rs/zerolog"
-    zlog "github.com/rs/zerolog/log"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/go-go-golems/bobatea/pkg/eventbus"
+	"github.com/go-go-golems/bobatea/pkg/repl"
+	"github.com/go-go-golems/bobatea/pkg/timeline"
+	"github.com/rs/zerolog"
+	zlog "github.com/rs/zerolog/log"
 )
 
 // DemoEvaluator: simple + shell
@@ -26,179 +26,199 @@ import (
 type DemoEvaluator struct{ CoalesceMs int }
 
 func (d DemoEvaluator) EvaluateStream(ctx context.Context, code string, emit func(repl.Event)) error {
-    code = strings.TrimSpace(code)
-    if strings.HasPrefix(code, "!") {
-        cmdStr := strings.TrimSpace(strings.TrimPrefix(code, "!"))
-        if cmdStr == "" { return nil }
-        zlog.Debug().Str("cmd", cmdStr).Msg("starting shell command")
-        cmd := exec.CommandContext(ctx, "bash", "-c", cmdStr)
-        stdout, _ := cmd.StdoutPipe()
-        stderr, _ := cmd.StderrPipe()
-        start := time.Now()
-        if err := cmd.Start(); err != nil {
-            emit(repl.Event{Kind: repl.EventStderr, Props: map[string]any{"append": err.Error() + "\n", "is_error": true}})
-            return err
-        }
+	code = strings.TrimSpace(code)
+	if strings.HasPrefix(code, "!") {
+		cmdStr := strings.TrimSpace(strings.TrimPrefix(code, "!"))
+		if cmdStr == "" {
+			return nil
+		}
+		zlog.Debug().Str("cmd", cmdStr).Msg("starting shell command")
+		cmd := exec.CommandContext(ctx, "bash", "-c", cmdStr)
+		stdout, _ := cmd.StdoutPipe()
+		stderr, _ := cmd.StderrPipe()
+		start := time.Now()
+		if err := cmd.Start(); err != nil {
+			emit(repl.Event{Kind: repl.EventStderr, Props: map[string]any{"append": err.Error() + "\n", "is_error": true}})
+			return err
+		}
 
-        // Coalescers
-        interval := d.CoalesceMs
-        if interval <= 0 { interval = 60 }
-        coalesce := func(ch <-chan string, kind repl.EventKind, extra map[string]any) {
-            ticker := time.NewTicker(time.Duration(interval) * time.Millisecond)
-            defer ticker.Stop()
-            buf := strings.Builder{}
-            flush := func() {
-                if buf.Len() == 0 { return }
-                props := map[string]any{"append": buf.String()}
-                for k, v := range extra { props[k] = v }
-                emit(repl.Event{Kind: kind, Props: props})
-                buf.Reset()
-            }
-            for {
-                select {
-                case line, ok := <-ch:
-                    if !ok { flush(); return }
-                    buf.WriteString(line)
-                    buf.WriteByte('\n')
-                case <-ticker.C:
-                    flush()
-                }
-            }
-        }
+		// Coalescers
+		interval := d.CoalesceMs
+		if interval <= 0 {
+			interval = 60
+		}
+		coalesce := func(ch <-chan string, kind repl.EventKind, extra map[string]any) {
+			ticker := time.NewTicker(time.Duration(interval) * time.Millisecond)
+			defer ticker.Stop()
+			buf := strings.Builder{}
+			flush := func() {
+				if buf.Len() == 0 {
+					return
+				}
+				props := map[string]any{"append": buf.String()}
+				for k, v := range extra {
+					props[k] = v
+				}
+				emit(repl.Event{Kind: kind, Props: props})
+				buf.Reset()
+			}
+			for {
+				select {
+				case line, ok := <-ch:
+					if !ok {
+						flush()
+						return
+					}
+					buf.WriteString(line)
+					buf.WriteByte('\n')
+				case <-ticker.C:
+					flush()
+				}
+			}
+		}
 
-        // Stream lines with coalescing to reduce UI churn
-        outCh := make(chan string, 1024)
-        errCh := make(chan string, 1024)
-        var wg sync.WaitGroup
-        wg.Add(4)
-        zlog.Debug().Msg("streaming stdout and stderr")
-        go func() { defer wg.Done(); streamLines(stdout, func(line string) { outCh <- line }) }()
-        go func() { defer wg.Done(); streamLines(stderr, func(line string) { errCh <- line }) }()
-        go func() { defer wg.Done(); coalesce(outCh, repl.EventStdout, map[string]any{}) }()
-        go func() { defer wg.Done(); coalesce(errCh, repl.EventStderr, map[string]any{"is_error": true}) }()
-        zlog.Debug().Msg("streaming stdout and stderr done")
+		// Stream lines with coalescing to reduce UI churn
+		outCh := make(chan string, 1024)
+		errCh := make(chan string, 1024)
+		var wg sync.WaitGroup
+		wg.Add(4)
+		zlog.Debug().Msg("streaming stdout and stderr")
+		go func() { defer wg.Done(); streamLines(stdout, func(line string) { outCh <- line }) }()
+		go func() { defer wg.Done(); streamLines(stderr, func(line string) { errCh <- line }) }()
+		go func() { defer wg.Done(); coalesce(outCh, repl.EventStdout, map[string]any{}) }()
+		go func() { defer wg.Done(); coalesce(errCh, repl.EventStderr, map[string]any{"is_error": true}) }()
+		zlog.Debug().Msg("streaming stdout and stderr done")
 
-        // Start coalescers and wait for process end
-        zlog.Debug().Msg("waiting for command to finish")
-        err := cmd.Wait()
-        close(outCh)
-        close(errCh)
-        wg.Wait()
-        dur := time.Since(start)
-        exit := 0
-        if err != nil { exit = 1 }
-        md := fmt.Sprintf("Command: `%s`\n\nExit: %d\nDuration: %s", cmdStr, exit, dur)
-        emit(repl.Event{Kind: repl.EventResultMarkdown, Props: map[string]any{"markdown": md}})
-        zlog.Debug().Str("cmd", cmdStr).Int("exit", exit).Dur("duration", dur).Msg("command finished")
+		// Start coalescers and wait for process end
+		zlog.Debug().Msg("waiting for command to finish")
+		err := cmd.Wait()
+		close(outCh)
+		close(errCh)
+		wg.Wait()
+		dur := time.Since(start)
+		exit := 0
+		if err != nil {
+			exit = 1
+		}
+		md := fmt.Sprintf("Command: `%s`\n\nExit: %d\nDuration: %s", cmdStr, exit, dur)
+		emit(repl.Event{Kind: repl.EventResultMarkdown, Props: map[string]any{"markdown": md}})
+		zlog.Debug().Str("cmd", cmdStr).Int("exit", exit).Dur("duration", dur).Msg("command finished")
 
-        return err
-    }
+		return err
+	}
 
-    // Simple markdown echo
-    md := fmt.Sprintf("You said:\n\n```\n%s\n```", code)
-    emit(repl.Event{Kind: repl.EventResultMarkdown, Props: map[string]any{"markdown": md}})
-    return nil
+	// Simple markdown echo
+	md := fmt.Sprintf("You said:\n\n```\n%s\n```", code)
+	emit(repl.Event{Kind: repl.EventResultMarkdown, Props: map[string]any{"markdown": md}})
+	return nil
 }
 
-func (d DemoEvaluator) GetPrompt() string           { return "> " }
-func (d DemoEvaluator) GetName() string             { return "Demo" }
-func (d DemoEvaluator) SupportsMultiline() bool     { return true }
-func (d DemoEvaluator) GetFileExtension() string    { return ".txt" }
+func (d DemoEvaluator) GetPrompt() string        { return "> " }
+func (d DemoEvaluator) GetName() string          { return "Demo" }
+func (d DemoEvaluator) SupportsMultiline() bool  { return true }
+func (d DemoEvaluator) GetFileExtension() string { return ".txt" }
 
 func streamLines(r any, onLine func(string)) {
-    // Minimal scanner using bufio
-    if rc, ok := r.(interface{ Read([]byte) (int, error) }); ok {
-        buf := make([]byte, 8192)
-        var acc strings.Builder
-        for {
-            n, err := rc.Read(buf)
-            if n > 0 {
-                chunk := string(buf[:n])
-                acc.WriteString(chunk)
-                for {
-                    s := acc.String()
-                    idx := strings.IndexByte(s, '\n')
-                    if idx < 0 { break }
-                    line := s[:idx]
-                    onLine(line)
-                    acc.Reset(); acc.WriteString(s[idx+1:])
-                }
-            }
-            if err != nil {
-                rem := acc.String()
-                if rem != "" { onLine(rem) }
-                return
-            }
-        }
-    }
+	// Minimal scanner using bufio
+	if rc, ok := r.(interface{ Read([]byte) (int, error) }); ok {
+		buf := make([]byte, 8192)
+		var acc strings.Builder
+		for {
+			n, err := rc.Read(buf)
+			if n > 0 {
+				chunk := string(buf[:n])
+				acc.WriteString(chunk)
+				for {
+					s := acc.String()
+					idx := strings.IndexByte(s, '\n')
+					if idx < 0 {
+						break
+					}
+					line := s[:idx]
+					onLine(line)
+					acc.Reset()
+					acc.WriteString(s[idx+1:])
+				}
+			}
+			if err != nil {
+				rem := acc.String()
+				if rem != "" {
+					onLine(rem)
+				}
+				return
+			}
+		}
+	}
 }
 
 func main() {
-    // logging: default to info, allow override via --log-level
-    var lvlFlag string
-    var logFile string
-    var coalesceMs int
-    flag.StringVar(&lvlFlag, "log-level", "error", "log level (trace, debug, info, warn, error)")
-    flag.StringVar(&logFile, "log-file", "", "path to write logs (JSON)")
-    flag.IntVar(&coalesceMs, "coalesce-ms", 60, "stdout/stderr coalescing interval (ms)")
-    flag.Parse()
+	// logging: default to info, allow override via --log-level
+	var lvlFlag string
+	var logFile string
+	var coalesceMs int
+	flag.StringVar(&lvlFlag, "log-level", "error", "log level (trace, debug, info, warn, error)")
+	flag.StringVar(&logFile, "log-file", "", "path to write logs (JSON)")
+	flag.IntVar(&coalesceMs, "coalesce-ms", 60, "stdout/stderr coalescing interval (ms)")
+	flag.Parse()
 
-    if parsed, err := zerolog.ParseLevel(lvlFlag); err == nil {
-        zerolog.SetGlobalLevel(parsed)
-    } else {
-        zerolog.SetGlobalLevel(zerolog.ErrorLevel)
-    }
-    if logFile != "" {
-        f, err := os.OpenFile(logFile, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644) // #nosec G302
-        if err == nil {
-            // setup zerolog console writer for human readable logs
-            consoleWriter := zerolog.ConsoleWriter{
-                Out:        f,
-                TimeFormat: "15:04:05",
-                NoColor:    true,
-            }
-            zlog.Logger = zerolog.New(consoleWriter).With().Timestamp().Logger()
-        }
-    } else {
-        // Avoid any console logging interfering with TUI
-        zlog.Logger = zerolog.New(io.Discard)
-    }
+	if parsed, err := zerolog.ParseLevel(lvlFlag); err == nil {
+		zerolog.SetGlobalLevel(parsed)
+	} else {
+		zerolog.SetGlobalLevel(zerolog.ErrorLevel)
+	}
+	if logFile != "" {
+		f, err := os.OpenFile(logFile, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644) // #nosec G302
+		if err == nil {
+			// setup zerolog console writer for human readable logs
+			consoleWriter := zerolog.ConsoleWriter{
+				Out:        f,
+				TimeFormat: "15:04:05",
+				NoColor:    true,
+			}
+			zlog.Logger = zerolog.New(consoleWriter).With().Timestamp().Logger()
+		}
+	} else {
+		// Avoid any console logging interfering with TUI
+		zlog.Logger = zerolog.New(io.Discard)
+	}
 
-    // Add caller info
-    zlog.Logger = zlog.Logger.With().Caller().Logger()
+	// Add caller info
+	zlog.Logger = zlog.Logger.With().Caller().Logger()
 
-    evaluator := DemoEvaluator{CoalesceMs: coalesceMs}
-    cfg := repl.Config{
-        Title:                "Timeline REPL Demo",
-        Placeholder:          "Type text, or !<shell command> (e.g., !echo hi)",
-        Width:                100,
-        StartMultiline:       false,
-        EnableExternalEditor: false,
-        EnableHistory:        true,
-        MaxHistorySize:       1000,
-    }
-    // Build in-memory bus
-    bus, err := eventbus.NewInMemoryBus()
-    if err != nil { log.Fatal(err) }
-    // Register transformer and UI forwarder
-    repl.RegisterReplToTimelineTransformer(bus)
+	evaluator := DemoEvaluator{CoalesceMs: coalesceMs}
+	cfg := repl.Config{
+		Title:                "Timeline REPL Demo",
+		Placeholder:          "Type text, or !<shell command> (e.g., !echo hi)",
+		Width:                100,
+		StartMultiline:       false,
+		EnableExternalEditor: false,
+		EnableHistory:        true,
+		MaxHistorySize:       1000,
+	}
+	// Build in-memory bus
+	bus, err := eventbus.NewInMemoryBus()
+	if err != nil {
+		log.Fatal(err)
+	}
+	// Register transformer and UI forwarder
+	repl.RegisterReplToTimelineTransformer(bus)
 
-    // Construct model with publisher
-    m := repl.NewModel(evaluator, cfg, bus.Publisher)
-    p := tea.NewProgram(m, tea.WithAltScreen())
-    timeline.RegisterUIForwarder(bus, p)
+	// Construct model with publisher
+	m := repl.NewModel(evaluator, cfg, bus.Publisher)
+	p := tea.NewProgram(m, tea.WithAltScreen())
+	timeline.RegisterUIForwarder(bus, p)
 
-    // Run router + program together
-    ctx, cancel := context.WithCancel(context.Background())
-    defer cancel()
-    errs := make(chan error, 2)
-    go func() { errs <- bus.Run(ctx) }()
-    go func() {
-        _, e := p.Run()
-        cancel()
-        errs <- e
-    }()
-    if e := <-errs; e != nil {
-        log.Fatal(e)
-    }
+	// Run router + program together
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	errs := make(chan error, 2)
+	go func() { errs <- bus.Run(ctx) }()
+	go func() {
+		_, e := p.Run()
+		cancel()
+		errs <- e
+	}()
+	if e := <-errs; e != nil {
+		log.Fatal(e)
+	}
 }

--- a/cmd/repl-timeline-demo/main.go
+++ b/cmd/repl-timeline-demo/main.go
@@ -1,0 +1,183 @@
+package main
+
+import (
+    "context"
+    "flag"
+    "fmt"
+    "log"
+    "io"
+    "os"
+    "os/exec"
+    "sync"
+    "strings"
+    "time"
+
+    tea "github.com/charmbracelet/bubbletea"
+    "github.com/go-go-golems/bobatea/pkg/repl"
+    "github.com/rs/zerolog"
+    zlog "github.com/rs/zerolog/log"
+)
+
+// DemoEvaluator: simple + shell
+// - If input starts with !, run shell after the ! and stream stdout/stderr
+// - Else, emit a markdown result echoing the input
+type DemoEvaluator struct{ CoalesceMs int }
+
+func (d DemoEvaluator) EvaluateStream(ctx context.Context, code string, emit func(repl.Event)) error {
+    code = strings.TrimSpace(code)
+    if strings.HasPrefix(code, "!") {
+        cmdStr := strings.TrimSpace(strings.TrimPrefix(code, "!"))
+        if cmdStr == "" { return nil }
+        zlog.Debug().Str("cmd", cmdStr).Msg("starting shell command")
+        cmd := exec.CommandContext(ctx, "bash", "-c", cmdStr)
+        stdout, _ := cmd.StdoutPipe()
+        stderr, _ := cmd.StderrPipe()
+        start := time.Now()
+        if err := cmd.Start(); err != nil {
+            emit(repl.Event{Kind: repl.EventStderr, Props: map[string]any{"append": err.Error() + "\n", "is_error": true}})
+            return err
+        }
+
+        // Coalescers
+        interval := d.CoalesceMs
+        if interval <= 0 { interval = 60 }
+        coalesce := func(ch <-chan string, kind repl.EventKind, extra map[string]any) {
+            ticker := time.NewTicker(time.Duration(interval) * time.Millisecond)
+            defer ticker.Stop()
+            buf := strings.Builder{}
+            flush := func() {
+                if buf.Len() == 0 { return }
+                props := map[string]any{"append": buf.String()}
+                for k, v := range extra { props[k] = v }
+                emit(repl.Event{Kind: kind, Props: props})
+                buf.Reset()
+            }
+            for {
+                select {
+                case line, ok := <-ch:
+                    if !ok { flush(); return }
+                    buf.WriteString(line)
+                    buf.WriteByte('\n')
+                case <-ticker.C:
+                    flush()
+                }
+            }
+        }
+
+        // Stream lines with coalescing to reduce UI churn
+        outCh := make(chan string, 1024)
+        errCh := make(chan string, 1024)
+        var wg sync.WaitGroup
+        wg.Add(4)
+        zlog.Debug().Msg("streaming stdout and stderr")
+        go func() { defer wg.Done(); streamLines(stdout, func(line string) { outCh <- line }) }()
+        go func() { defer wg.Done(); streamLines(stderr, func(line string) { errCh <- line }) }()
+        go func() { defer wg.Done(); coalesce(outCh, repl.EventStdout, map[string]any{}) }()
+        go func() { defer wg.Done(); coalesce(errCh, repl.EventStderr, map[string]any{"is_error": true}) }()
+        zlog.Debug().Msg("streaming stdout and stderr done")
+
+        // Start coalescers and wait for process end
+        zlog.Debug().Msg("waiting for command to finish")
+        err := cmd.Wait()
+        close(outCh)
+        close(errCh)
+        wg.Wait()
+        dur := time.Since(start)
+        exit := 0
+        if err != nil { exit = 1 }
+        md := fmt.Sprintf("Command: `%s`\n\nExit: %d\nDuration: %s", cmdStr, exit, dur)
+        emit(repl.Event{Kind: repl.EventResultMarkdown, Props: map[string]any{"markdown": md}})
+        zlog.Debug().Str("cmd", cmdStr).Int("exit", exit).Dur("duration", dur).Msg("command finished")
+
+        return err
+    }
+
+    // Simple markdown echo
+    md := fmt.Sprintf("You said:\n\n```\n%s\n```", code)
+    emit(repl.Event{Kind: repl.EventResultMarkdown, Props: map[string]any{"markdown": md}})
+    return nil
+}
+
+func (d DemoEvaluator) GetPrompt() string           { return "> " }
+func (d DemoEvaluator) GetName() string             { return "Demo" }
+func (d DemoEvaluator) SupportsMultiline() bool     { return true }
+func (d DemoEvaluator) GetFileExtension() string    { return ".txt" }
+
+func streamLines(r any, onLine func(string)) {
+    // Minimal scanner using bufio
+    if rc, ok := r.(interface{ Read([]byte) (int, error) }); ok {
+        buf := make([]byte, 8192)
+        var acc strings.Builder
+        for {
+            n, err := rc.Read(buf)
+            if n > 0 {
+                chunk := string(buf[:n])
+                acc.WriteString(chunk)
+                for {
+                    s := acc.String()
+                    idx := strings.IndexByte(s, '\n')
+                    if idx < 0 { break }
+                    line := s[:idx]
+                    onLine(line)
+                    acc.Reset(); acc.WriteString(s[idx+1:])
+                }
+            }
+            if err != nil {
+                rem := acc.String()
+                if rem != "" { onLine(rem) }
+                return
+            }
+        }
+    }
+}
+
+func main() {
+    // logging: default to info, allow override via --log-level
+    var lvlFlag string
+    var logFile string
+    var coalesceMs int
+    flag.StringVar(&lvlFlag, "log-level", "error", "log level (trace, debug, info, warn, error)")
+    flag.StringVar(&logFile, "log-file", "", "path to write logs (JSON)")
+    flag.IntVar(&coalesceMs, "coalesce-ms", 60, "stdout/stderr coalescing interval (ms)")
+    flag.Parse()
+
+    if parsed, err := zerolog.ParseLevel(lvlFlag); err == nil {
+        zerolog.SetGlobalLevel(parsed)
+    } else {
+        zerolog.SetGlobalLevel(zerolog.ErrorLevel)
+    }
+    if logFile != "" {
+        f, err := os.OpenFile(logFile, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644) // #nosec G302
+        if err == nil {
+            // setup zerolog console writer for human readable logs
+            consoleWriter := zerolog.ConsoleWriter{
+                Out:        f,
+                TimeFormat: "15:04:05",
+                NoColor:    true,
+            }
+            zlog.Logger = zerolog.New(consoleWriter).With().Timestamp().Logger()
+        }
+    } else {
+        // Avoid any console logging interfering with TUI
+        zlog.Logger = zerolog.New(io.Discard)
+    }
+
+    // Add caller info
+    zlog.Logger = zlog.Logger.With().Caller().Logger()
+
+    evaluator := DemoEvaluator{CoalesceMs: coalesceMs}
+    cfg := repl.Config{
+        Title:                "Timeline REPL Demo",
+        Placeholder:          "Type text, or !<shell command> (e.g., !echo hi)",
+        Width:                100,
+        StartMultiline:       false,
+        EnableExternalEditor: false,
+        EnableHistory:        true,
+        MaxHistorySize:       1000,
+    }
+    m := repl.NewModel(evaluator, cfg)
+    p := tea.NewProgram(m, tea.WithAltScreen())
+    if _, err := p.Run(); err != nil {
+        log.Fatal(err)
+    }
+}

--- a/examples/js-repl/main.go
+++ b/examples/js-repl/main.go
@@ -2,13 +2,19 @@ package main
 
 import (
 	"context"
+	"flag"
 	"fmt"
 	"log"
+	"strings"
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/dop251/goja"
+	"github.com/go-go-golems/bobatea/pkg/eventbus"
+	"github.com/go-go-golems/bobatea/pkg/logutil"
 	"github.com/go-go-golems/bobatea/pkg/repl"
+	"github.com/go-go-golems/bobatea/pkg/timeline"
 	ggjengine "github.com/go-go-golems/go-go-goja/engine"
+	"github.com/rs/zerolog"
 )
 
 // JSEvaluator implements JavaScript evaluation using goja
@@ -20,18 +26,6 @@ type JSEvaluator struct {
 func NewJSEvaluator() (*JSEvaluator, error) {
 	// Create a Goja runtime with Node-style require() and native modules enabled
 	vm, _ := ggjengine.New()
-
-	// Override console.log to write directly to stdout without timestamps
-	consoleObj := vm.NewObject()
-	_ = consoleObj.Set("log", func(call goja.FunctionCall) goja.Value {
-		var args []interface{}
-		for _, arg := range call.Arguments {
-			args = append(args, arg.Export())
-		}
-		fmt.Println(args...)
-		return goja.Undefined()
-	})
-	_ = vm.Set("console", consoleObj)
 
 	return &JSEvaluator{runtime: vm}, nil
 }
@@ -50,6 +44,78 @@ func (e *JSEvaluator) Evaluate(ctx context.Context, code string) (string, error)
 	return "undefined", nil
 }
 
+func (e *JSEvaluator) EvaluateStream(ctx context.Context, code string, emit func(repl.Event)) error {
+	// Override console functions to stream as timeline entities
+	vm := e.runtime
+	consoleObj := vm.NewObject()
+	_ = consoleObj.Set("log", func(call goja.FunctionCall) goja.Value {
+		if len(call.Arguments) == 1 {
+			v := call.Arguments[0].Export()
+			switch v.(type) {
+			case map[string]any, map[interface{}]interface{}, []any:
+				// Structured event log, rendered as YAML (no markdown fences)
+				emit(repl.Event{Kind: repl.EventStructuredLog, Props: map[string]any{"level": "info", "data": v}})
+				return goja.Undefined()
+			}
+		}
+		// Otherwise, plain log entry
+		parts := make([]string, 0, len(call.Arguments))
+		for _, arg := range call.Arguments {
+			parts = append(parts, fmt.Sprint(arg.Export()))
+		}
+		s := strings.Join(parts, " ")
+		emit(repl.Event{Kind: repl.EventLog, Props: map[string]any{"level": "info", "message": s}})
+		return goja.Undefined()
+	})
+	_ = consoleObj.Set("error", func(call goja.FunctionCall) goja.Value {
+		if len(call.Arguments) == 1 {
+			v := call.Arguments[0].Export()
+			switch v.(type) {
+			case map[string]any, map[interface{}]interface{}, []any:
+				emit(repl.Event{Kind: repl.EventStructuredLog, Props: map[string]any{"level": "error", "data": v}})
+				return goja.Undefined()
+			}
+		}
+		parts := make([]string, 0, len(call.Arguments))
+		for _, arg := range call.Arguments {
+			parts = append(parts, fmt.Sprint(arg.Export()))
+		}
+		s := strings.Join(parts, " ")
+		emit(repl.Event{Kind: repl.EventLog, Props: map[string]any{"level": "error", "message": s}})
+		return goja.Undefined()
+	})
+	_ = consoleObj.Set("warn", func(call goja.FunctionCall) goja.Value {
+		if len(call.Arguments) == 1 {
+			v := call.Arguments[0].Export()
+			switch v.(type) {
+			case map[string]any, map[interface{}]interface{}, []any:
+				emit(repl.Event{Kind: repl.EventStructuredLog, Props: map[string]any{"level": "warn", "data": v}})
+				return goja.Undefined()
+			}
+		}
+		parts := make([]string, 0, len(call.Arguments))
+		for _, arg := range call.Arguments {
+			parts = append(parts, fmt.Sprint(arg.Export()))
+		}
+		s := strings.Join(parts, " ")
+		emit(repl.Event{Kind: repl.EventLog, Props: map[string]any{"level": "warn", "message": s}})
+		return goja.Undefined()
+	})
+	_ = vm.Set("console", consoleObj)
+
+	// Execute code and emit result
+	res, err := vm.RunString(code)
+	if err != nil {
+		emit(repl.Event{Kind: repl.EventResultMarkdown, Props: map[string]any{"markdown": fmt.Sprintf("Error: %v", err)}})
+		return nil
+	}
+	if res != nil && !goja.IsUndefined(res) {
+		out := res.String()
+		emit(repl.Event{Kind: repl.EventResultMarkdown, Props: map[string]any{"markdown": out}})
+	}
+	return nil
+}
+
 func (e *JSEvaluator) GetPrompt() string {
 	return "js> "
 }
@@ -66,7 +132,36 @@ func (e *JSEvaluator) GetFileExtension() string {
 	return ".js"
 }
 
+func parseLevel(s string) zerolog.Level {
+	switch strings.ToLower(s) {
+	case "trace":
+		return zerolog.TraceLevel
+	case "debug":
+		return zerolog.DebugLevel
+	case "info":
+		return zerolog.InfoLevel
+	case "warn", "warning":
+		return zerolog.WarnLevel
+	case "error", "err":
+		return zerolog.ErrorLevel
+	default:
+		return zerolog.ErrorLevel
+	}
+}
+
 func main() {
+	// CLI flags for logging
+	ll := flag.String("log-level", "error", "log level: trace, debug, info, warn, error")
+	lf := flag.String("log-file", "", "log file path (optional)")
+	flag.Parse()
+
+	level := parseLevel(*ll)
+	if *lf != "" {
+		logutil.InitTUILoggingToFile(level, *lf)
+	} else {
+		logutil.InitTUILoggingToDiscard(level)
+	}
+
 	// Create the evaluator
 	evaluator, err := NewJSEvaluator()
 	if err != nil {
@@ -78,12 +173,23 @@ func main() {
 	config.Title = "JavaScript REPL"
 	config.Placeholder = "Enter JavaScript code or /command"
 
-	// Create the model
-	model := repl.NewModel(evaluator, config)
-
-	// Run the program
-	p := tea.NewProgram(model, tea.WithAltScreen())
-	if _, err := p.Run(); err != nil {
+	// Wire bus and forwarders
+	bus, err := eventbus.NewInMemoryBus()
+	if err != nil {
 		log.Fatal(err)
+	}
+	repl.RegisterReplToTimelineTransformer(bus)
+
+	model := repl.NewModel(evaluator, config, bus.Publisher)
+	p := tea.NewProgram(model, tea.WithAltScreen())
+	timeline.RegisterUIForwarder(bus, p)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	errs := make(chan error, 2)
+	go func() { errs <- bus.Run(ctx) }()
+	go func() { _, e := p.Run(); cancel(); errs <- e }()
+	if e := <-errs; e != nil {
+		log.Fatal(e)
 	}
 }

--- a/examples/repl/basic-usage/main.go
+++ b/examples/repl/basic-usage/main.go
@@ -1,40 +1,40 @@
 package main
 
 import (
-    "context"
-    "fmt"
-    "log"
-    "strconv"
-    "strings"
-    
-    tea "github.com/charmbracelet/bubbletea"
-    "github.com/go-go-golems/bobatea/pkg/eventbus"
-    "github.com/go-go-golems/bobatea/pkg/repl"
-    "github.com/go-go-golems/bobatea/pkg/timeline"
-    "github.com/rs/zerolog"
-    zlog "github.com/rs/zerolog/log"
-    "io"
+	"context"
+	"fmt"
+	"log"
+	"strconv"
+	"strings"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/go-go-golems/bobatea/pkg/eventbus"
+	"github.com/go-go-golems/bobatea/pkg/repl"
+	"github.com/go-go-golems/bobatea/pkg/timeline"
+	"github.com/rs/zerolog"
+	zlog "github.com/rs/zerolog/log"
+	"io"
 )
 
 // EchoEvaluator is a simple evaluator that echoes back the input
 type EchoEvaluator struct{}
 
 func (e *EchoEvaluator) EvaluateStream(ctx context.Context, code string, emit func(repl.Event)) error {
-    code = strings.TrimSpace(code)
-    if code == "" {
-        emit(repl.Event{Kind: repl.EventResultMarkdown, Props: map[string]any{"markdown": "Empty input"}})
-        return nil
-    }
-    if num, err := strconv.Atoi(code); err == nil {
-        emit(repl.Event{Kind: repl.EventResultMarkdown, Props: map[string]any{"markdown": fmt.Sprintf("Number: %d (hex: 0x%x)", num, num)}})
-        return nil
-    }
-    if strings.HasPrefix(strings.ToLower(code), "hello") {
-        emit(repl.Event{Kind: repl.EventResultMarkdown, Props: map[string]any{"markdown": "Hello there! 👋"}})
-        return nil
-    }
-    emit(repl.Event{Kind: repl.EventResultMarkdown, Props: map[string]any{"markdown": fmt.Sprintf("You said: %s", code)}})
-    return nil
+	code = strings.TrimSpace(code)
+	if code == "" {
+		emit(repl.Event{Kind: repl.EventResultMarkdown, Props: map[string]any{"markdown": "Empty input"}})
+		return nil
+	}
+	if num, err := strconv.Atoi(code); err == nil {
+		emit(repl.Event{Kind: repl.EventResultMarkdown, Props: map[string]any{"markdown": fmt.Sprintf("Number: %d (hex: 0x%x)", num, num)}})
+		return nil
+	}
+	if strings.HasPrefix(strings.ToLower(code), "hello") {
+		emit(repl.Event{Kind: repl.EventResultMarkdown, Props: map[string]any{"markdown": "Hello there! 👋"}})
+		return nil
+	}
+	emit(repl.Event{Kind: repl.EventResultMarkdown, Props: map[string]any{"markdown": fmt.Sprintf("You said: %s", code)}})
+	return nil
 }
 
 func (e *EchoEvaluator) GetPrompt() string        { return "echo> " }
@@ -43,32 +43,36 @@ func (e *EchoEvaluator) SupportsMultiline() bool  { return false }
 func (e *EchoEvaluator) GetFileExtension() string { return ".txt" }
 
 func main() {
-    // Initialize logging (avoid stdout noise in TUI)
-    zerolog.SetGlobalLevel(zerolog.ErrorLevel)
-    zlog.Logger = zerolog.New(io.Discard)
+	// Initialize logging (avoid stdout noise in TUI)
+	zerolog.SetGlobalLevel(zerolog.ErrorLevel)
+	zlog.Logger = zerolog.New(io.Discard)
 
-    // Create the evaluator
-    evaluator := &EchoEvaluator{}
+	// Create the evaluator
+	evaluator := &EchoEvaluator{}
 
-    // Create a basic configuration
-    config := repl.DefaultConfig()
-    config.Title = "Basic Echo REPL"
-    config.Placeholder = "Type something to echo back..."
-    config.Width = 80
+	// Create a basic configuration
+	config := repl.DefaultConfig()
+	config.Title = "Basic Echo REPL"
+	config.Placeholder = "Type something to echo back..."
+	config.Width = 80
 
-    // Build in-memory bus and wire transformer + forwarder
-    bus, err := eventbus.NewInMemoryBus()
-    if err != nil { log.Fatal(err) }
-    repl.RegisterReplToTimelineTransformer(bus)
+	// Build in-memory bus and wire transformer + forwarder
+	bus, err := eventbus.NewInMemoryBus()
+	if err != nil {
+		log.Fatal(err)
+	}
+	repl.RegisterReplToTimelineTransformer(bus)
 
-    model := repl.NewModel(evaluator, config, bus.Publisher)
-    p := tea.NewProgram(model, tea.WithAltScreen())
-    timeline.RegisterUIForwarder(bus, p)
+	model := repl.NewModel(evaluator, config, bus.Publisher)
+	p := tea.NewProgram(model, tea.WithAltScreen())
+	timeline.RegisterUIForwarder(bus, p)
 
-    ctx, cancel := context.WithCancel(context.Background())
-    defer cancel()
-    errs := make(chan error, 2)
-    go func() { errs <- bus.Run(ctx) }()
-    go func() { _, e := p.Run(); cancel(); errs <- e }()
-    if e := <-errs; e != nil { log.Fatal(e) }
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	errs := make(chan error, 2)
+	go func() { errs <- bus.Run(ctx) }()
+	go func() { _, e := p.Run(); cancel(); errs <- e }()
+	if e := <-errs; e != nil {
+		log.Fatal(e)
+	}
 }

--- a/examples/repl/basic-usage/main.go
+++ b/examples/repl/basic-usage/main.go
@@ -1,72 +1,74 @@
 package main
 
 import (
-	"context"
-	"fmt"
-	"log"
-	"strconv"
-	"strings"
-
-	tea "github.com/charmbracelet/bubbletea"
-	"github.com/go-go-golems/bobatea/pkg/repl"
+    "context"
+    "fmt"
+    "log"
+    "strconv"
+    "strings"
+    
+    tea "github.com/charmbracelet/bubbletea"
+    "github.com/go-go-golems/bobatea/pkg/eventbus"
+    "github.com/go-go-golems/bobatea/pkg/repl"
+    "github.com/go-go-golems/bobatea/pkg/timeline"
+    "github.com/rs/zerolog"
+    zlog "github.com/rs/zerolog/log"
+    "io"
 )
 
 // EchoEvaluator is a simple evaluator that echoes back the input
 type EchoEvaluator struct{}
 
-func (e *EchoEvaluator) Evaluate(ctx context.Context, code string) (string, error) {
-	// Simple echo with some formatting
-	code = strings.TrimSpace(code)
-	if code == "" {
-		return "Empty input", nil
-	}
-
-	// If it's a number, show it as both decimal and hex
-	if num, err := strconv.Atoi(code); err == nil {
-		return fmt.Sprintf("Number: %d (hex: 0x%x)", num, num), nil
-	}
-
-	// If it's a greeting, respond nicely
-	if strings.HasPrefix(strings.ToLower(code), "hello") {
-		return "Hello there! 👋", nil
-	}
-
-	// Otherwise, just echo it back
-	return fmt.Sprintf("You said: %s", code), nil
+func (e *EchoEvaluator) EvaluateStream(ctx context.Context, code string, emit func(repl.Event)) error {
+    code = strings.TrimSpace(code)
+    if code == "" {
+        emit(repl.Event{Kind: repl.EventResultMarkdown, Props: map[string]any{"markdown": "Empty input"}})
+        return nil
+    }
+    if num, err := strconv.Atoi(code); err == nil {
+        emit(repl.Event{Kind: repl.EventResultMarkdown, Props: map[string]any{"markdown": fmt.Sprintf("Number: %d (hex: 0x%x)", num, num)}})
+        return nil
+    }
+    if strings.HasPrefix(strings.ToLower(code), "hello") {
+        emit(repl.Event{Kind: repl.EventResultMarkdown, Props: map[string]any{"markdown": "Hello there! 👋"}})
+        return nil
+    }
+    emit(repl.Event{Kind: repl.EventResultMarkdown, Props: map[string]any{"markdown": fmt.Sprintf("You said: %s", code)}})
+    return nil
 }
 
-func (e *EchoEvaluator) GetPrompt() string {
-	return "echo> "
-}
-
-func (e *EchoEvaluator) GetName() string {
-	return "Echo"
-}
-
-func (e *EchoEvaluator) SupportsMultiline() bool {
-	return false
-}
-
-func (e *EchoEvaluator) GetFileExtension() string {
-	return ".txt"
-}
+func (e *EchoEvaluator) GetPrompt() string        { return "echo> " }
+func (e *EchoEvaluator) GetName() string          { return "Echo" }
+func (e *EchoEvaluator) SupportsMultiline() bool  { return false }
+func (e *EchoEvaluator) GetFileExtension() string { return ".txt" }
 
 func main() {
-	// Create the evaluator
-	evaluator := &EchoEvaluator{}
+    // Initialize logging (avoid stdout noise in TUI)
+    zerolog.SetGlobalLevel(zerolog.ErrorLevel)
+    zlog.Logger = zerolog.New(io.Discard)
 
-	// Create a basic configuration
-	config := repl.DefaultConfig()
-	config.Title = "Basic Echo REPL"
-	config.Placeholder = "Type something to echo back..."
-	config.Width = 80
+    // Create the evaluator
+    evaluator := &EchoEvaluator{}
 
-	// Create the REPL model
-	model := repl.NewModel(evaluator, config)
+    // Create a basic configuration
+    config := repl.DefaultConfig()
+    config.Title = "Basic Echo REPL"
+    config.Placeholder = "Type something to echo back..."
+    config.Width = 80
 
-	// Run the program
-	p := tea.NewProgram(model, tea.WithAltScreen())
-	if _, err := p.Run(); err != nil {
-		log.Fatal(err)
-	}
+    // Build in-memory bus and wire transformer + forwarder
+    bus, err := eventbus.NewInMemoryBus()
+    if err != nil { log.Fatal(err) }
+    repl.RegisterReplToTimelineTransformer(bus)
+
+    model := repl.NewModel(evaluator, config, bus.Publisher)
+    p := tea.NewProgram(model, tea.WithAltScreen())
+    timeline.RegisterUIForwarder(bus, p)
+
+    ctx, cancel := context.WithCancel(context.Background())
+    defer cancel()
+    errs := make(chan error, 2)
+    go func() { errs <- bus.Run(ctx) }()
+    go func() { _, e := p.Run(); cancel(); errs <- e }()
+    if e := <-errs; e != nil { log.Fatal(e) }
 }

--- a/examples/repl/custom-evaluator/main.go
+++ b/examples/repl/custom-evaluator/main.go
@@ -1,20 +1,20 @@
 package main
 
 import (
-    "context"
-    "fmt"
-    "log"
-    "math"
-    "regexp"
-    "strconv"
-    "strings"
+	"context"
+	"fmt"
+	"log"
+	"math"
+	"regexp"
+	"strconv"
+	"strings"
 
-    tea "github.com/charmbracelet/bubbletea"
-    "github.com/go-go-golems/bobatea/pkg/eventbus"
-    "github.com/go-go-golems/bobatea/pkg/logutil"
-    "github.com/go-go-golems/bobatea/pkg/repl"
-    "github.com/go-go-golems/bobatea/pkg/timeline"
-    "github.com/rs/zerolog"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/go-go-golems/bobatea/pkg/eventbus"
+	"github.com/go-go-golems/bobatea/pkg/logutil"
+	"github.com/go-go-golems/bobatea/pkg/repl"
+	"github.com/go-go-golems/bobatea/pkg/timeline"
+	"github.com/rs/zerolog"
 )
 
 // AdvancedCalculatorEvaluator is a more sophisticated calculator
@@ -49,51 +49,51 @@ func NewAdvancedCalculatorEvaluator() *AdvancedCalculatorEvaluator {
 }
 
 func (e *AdvancedCalculatorEvaluator) EvaluateStream(ctx context.Context, code string, emit func(repl.Event)) error {
-    code = strings.TrimSpace(code)
-    if code == "" {
-        emit(repl.Event{Kind: repl.EventResultMarkdown, Props: map[string]any{"markdown": "Empty expression"}})
-        return nil
-    }
+	code = strings.TrimSpace(code)
+	if code == "" {
+		emit(repl.Event{Kind: repl.EventResultMarkdown, Props: map[string]any{"markdown": "Empty expression"}})
+		return nil
+	}
 
 	// Add to history
 	e.history = append(e.history, code)
 
-    // Handle variable assignment: x = 42
-    if strings.Contains(code, "=") && !strings.Contains(code, "==") {
-        out, err := e.handleAssignment(code)
-        if err != nil {
-            emit(repl.Event{Kind: repl.EventResultMarkdown, Props: map[string]any{"markdown": fmt.Sprintf("Error: %v", err)}})
-            return nil
-        }
-        emit(repl.Event{Kind: repl.EventResultMarkdown, Props: map[string]any{"markdown": out}})
-        return nil
-    }
+	// Handle variable assignment: x = 42
+	if strings.Contains(code, "=") && !strings.Contains(code, "==") {
+		out, err := e.handleAssignment(code)
+		if err != nil {
+			emit(repl.Event{Kind: repl.EventResultMarkdown, Props: map[string]any{"markdown": fmt.Sprintf("Error: %v", err)}})
+			return nil
+		}
+		emit(repl.Event{Kind: repl.EventResultMarkdown, Props: map[string]any{"markdown": out}})
+		return nil
+	}
 
 	// Handle special commands
-    if strings.HasPrefix(code, "vars") {
-        emit(repl.Event{Kind: repl.EventResultMarkdown, Props: map[string]any{"markdown": e.showVariables()}})
-        return nil
-    }
+	if strings.HasPrefix(code, "vars") {
+		emit(repl.Event{Kind: repl.EventResultMarkdown, Props: map[string]any{"markdown": e.showVariables()}})
+		return nil
+	}
 
-    if strings.HasPrefix(code, "funcs") {
-        emit(repl.Event{Kind: repl.EventResultMarkdown, Props: map[string]any{"markdown": e.showFunctions()}})
-        return nil
-    }
+	if strings.HasPrefix(code, "funcs") {
+		emit(repl.Event{Kind: repl.EventResultMarkdown, Props: map[string]any{"markdown": e.showFunctions()}})
+		return nil
+	}
 
-    if strings.HasPrefix(code, "hist") {
-        emit(repl.Event{Kind: repl.EventResultMarkdown, Props: map[string]any{"markdown": e.showHistory()}})
-        return nil
-    }
+	if strings.HasPrefix(code, "hist") {
+		emit(repl.Event{Kind: repl.EventResultMarkdown, Props: map[string]any{"markdown": e.showHistory()}})
+		return nil
+	}
 
 	// Evaluate mathematical expression
-    result, err := e.evaluateExpression(code)
-    if err != nil {
-        emit(repl.Event{Kind: repl.EventResultMarkdown, Props: map[string]any{"markdown": fmt.Sprintf("Error: %v", err)}})
-        return nil
-    }
-    e.variables["ans"] = result
-    emit(repl.Event{Kind: repl.EventResultMarkdown, Props: map[string]any{"markdown": fmt.Sprintf("%.6g", result)}})
-    return nil
+	result, err := e.evaluateExpression(code)
+	if err != nil {
+		emit(repl.Event{Kind: repl.EventResultMarkdown, Props: map[string]any{"markdown": fmt.Sprintf("Error: %v", err)}})
+		return nil
+	}
+	e.variables["ans"] = result
+	emit(repl.Event{Kind: repl.EventResultMarkdown, Props: map[string]any{"markdown": fmt.Sprintf("%.6g", result)}})
+	return nil
 }
 
 func (e *AdvancedCalculatorEvaluator) handleAssignment(code string) (string, error) {
@@ -288,32 +288,36 @@ func (e *AdvancedCalculatorEvaluator) GetFileExtension() string {
 }
 
 func main() {
-    // Silence logs for TUI
-    logutil.InitTUILoggingToDiscard(zerolog.ErrorLevel)
+	// Silence logs for TUI
+	logutil.InitTUILoggingToDiscard(zerolog.ErrorLevel)
 
-    evaluator := NewAdvancedCalculatorEvaluator()
-    config := repl.Config{
-        Title:                "Advanced Calculator REPL",
-        Placeholder:          "Enter mathematical expression...",
-        Width:                100,
-        StartMultiline:       false,
-        EnableExternalEditor: true,
-        EnableHistory:        true,
-        MaxHistorySize:       500,
-    }
+	evaluator := NewAdvancedCalculatorEvaluator()
+	config := repl.Config{
+		Title:                "Advanced Calculator REPL",
+		Placeholder:          "Enter mathematical expression...",
+		Width:                100,
+		StartMultiline:       false,
+		EnableExternalEditor: true,
+		EnableHistory:        true,
+		MaxHistorySize:       500,
+	}
 
-    bus, err := eventbus.NewInMemoryBus()
-    if err != nil { log.Fatal(err) }
-    repl.RegisterReplToTimelineTransformer(bus)
+	bus, err := eventbus.NewInMemoryBus()
+	if err != nil {
+		log.Fatal(err)
+	}
+	repl.RegisterReplToTimelineTransformer(bus)
 
-    model := repl.NewModel(evaluator, config, bus.Publisher)
-    p := tea.NewProgram(model, tea.WithAltScreen())
-    timeline.RegisterUIForwarder(bus, p)
+	model := repl.NewModel(evaluator, config, bus.Publisher)
+	p := tea.NewProgram(model, tea.WithAltScreen())
+	timeline.RegisterUIForwarder(bus, p)
 
-    ctx, cancel := context.WithCancel(context.Background())
-    defer cancel()
-    errs := make(chan error, 2)
-    go func() { errs <- bus.Run(ctx) }()
-    go func() { _, e := p.Run(); cancel(); errs <- e }()
-    if e := <-errs; e != nil { log.Fatal(e) }
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	errs := make(chan error, 2)
+	go func() { errs <- bus.Run(ctx) }()
+	go func() { _, e := p.Run(); cancel(); errs <- e }()
+	if e := <-errs; e != nil {
+		log.Fatal(e)
+	}
 }

--- a/examples/repl/custom-theme/main.go
+++ b/examples/repl/custom-theme/main.go
@@ -6,6 +6,7 @@ import (
     "log"
     "strings"
 
+    "github.com/charmbracelet/lipgloss"
     tea "github.com/charmbracelet/bubbletea"
     "github.com/go-go-golems/bobatea/pkg/eventbus"
     "github.com/go-go-golems/bobatea/pkg/logutil"
@@ -25,35 +26,30 @@ func NewThemeDemo() *ThemeDemo {
 	}
 }
 
-func (e *ThemeDemo) Evaluate(ctx context.Context, code string) (string, error) {
-	code = strings.TrimSpace(code)
+func (e *ThemeDemo) EvaluateStream(ctx context.Context, code string, emit func(repl.Event)) error {
+    code = strings.TrimSpace(code)
 
-	if code == "" {
-		return "Empty input", nil
-	}
+    if code == "" {
+        emit(repl.Event{Kind: repl.EventResultMarkdown, Props: map[string]any{"markdown": "Empty input"}})
+        return nil
+    }
 
-	// Handle theme-related commands
-	if strings.HasPrefix(code, "theme ") {
-		themeName := strings.TrimPrefix(code, "theme ")
-		e.currentTheme = themeName
-		return fmt.Sprintf("Theme changed to: %s", themeName), nil
-	}
+    // Demonstrate colorful output
+    switch code {
+    case "rainbow":
+        emit(repl.Event{Kind: repl.EventResultMarkdown, Props: map[string]any{"markdown": "🌈 Rainbow colors! 🌈"}})
+        return nil
+    case "colors":
+        emit(repl.Event{Kind: repl.EventResultMarkdown, Props: map[string]any{"markdown": "Red, Green, Blue, Yellow, Magenta, Cyan"}})
+        return nil
+    case "demo":
+        emit(repl.Event{Kind: repl.EventResultMarkdown, Props: map[string]any{"markdown": "This is a demonstration of themed output!\nTry different themes to see the styling change."}})
+        return nil
+    }
 
-	// Demonstrate colorful output
-	if code == "rainbow" {
-		return "🌈 Rainbow colors! 🌈", nil
-	}
-
-	if code == "colors" {
-		return "Red, Green, Blue, Yellow, Magenta, Cyan", nil
-	}
-
-	if code == "demo" {
-		return "This is a demonstration of themed output!\nTry different themes to see the styling change.", nil
-	}
-
-	// Default response
-	return fmt.Sprintf("Current theme: %s | You said: %s", e.currentTheme, code), nil
+    // Default response
+    emit(repl.Event{Kind: repl.EventResultMarkdown, Props: map[string]any{"markdown": fmt.Sprintf("Current theme: %s | You said: %s", e.currentTheme, code)}})
+    return nil
 }
 
 func (e *ThemeDemo) GetPrompt() string {
@@ -72,377 +68,60 @@ func (e *ThemeDemo) GetFileExtension() string {
 	return ".theme"
 }
 
-// Custom themes
-var customThemes = map[string]repl.Theme{
-	"cyberpunk": {
-		Name: "Cyberpunk",
-		Styles: repl.Styles{
-			Title: lipgloss.NewStyle().
-				Bold(true).
-				Foreground(lipgloss.Color("15")).
-				Background(lipgloss.Color("55")).
-				Padding(0, 1),
-
-			Prompt: lipgloss.NewStyle().
-				Foreground(lipgloss.Color("51")).
-				Bold(true),
-
-			Result: lipgloss.NewStyle().
-				Foreground(lipgloss.Color("46")),
-
-			Error: lipgloss.NewStyle().
-				Foreground(lipgloss.Color("196")).
-				Bold(true),
-
-			Info: lipgloss.NewStyle().
-				Foreground(lipgloss.Color("226")).
-				Italic(true),
-
-			HelpText: lipgloss.NewStyle().
-				Foreground(lipgloss.Color("201")).
-				Italic(true),
-		},
-	},
-
-	"ocean": {
-		Name: "Ocean",
-		Styles: repl.Styles{
-			Title: lipgloss.NewStyle().
-				Bold(true).
-				Foreground(lipgloss.Color("15")).
-				Background(lipgloss.Color("24")).
-				Padding(0, 1),
-
-			Prompt: lipgloss.NewStyle().
-				Foreground(lipgloss.Color("39")).
-				Bold(true),
-
-			Result: lipgloss.NewStyle().
-				Foreground(lipgloss.Color("117")),
-
-			Error: lipgloss.NewStyle().
-				Foreground(lipgloss.Color("203")).
-				Bold(true),
-
-			Info: lipgloss.NewStyle().
-				Foreground(lipgloss.Color("123")).
-				Italic(true),
-
-			HelpText: lipgloss.NewStyle().
-				Foreground(lipgloss.Color("67")).
-				Italic(true),
-		},
-	},
-
-	"forest": {
-		Name: "Forest",
-		Styles: repl.Styles{
-			Title: lipgloss.NewStyle().
-				Bold(true).
-				Foreground(lipgloss.Color("15")).
-				Background(lipgloss.Color("22")).
-				Padding(0, 1),
-
-			Prompt: lipgloss.NewStyle().
-				Foreground(lipgloss.Color("34")).
-				Bold(true),
-
-			Result: lipgloss.NewStyle().
-				Foreground(lipgloss.Color("120")),
-
-			Error: lipgloss.NewStyle().
-				Foreground(lipgloss.Color("160")).
-				Bold(true),
-
-			Info: lipgloss.NewStyle().
-				Foreground(lipgloss.Color("142")).
-				Italic(true),
-
-			HelpText: lipgloss.NewStyle().
-				Foreground(lipgloss.Color("100")).
-				Italic(true),
-		},
-	},
-
-	"sunset": {
-		Name: "Sunset",
-		Styles: repl.Styles{
-			Title: lipgloss.NewStyle().
-				Bold(true).
-				Foreground(lipgloss.Color("15")).
-				Background(lipgloss.Color("124")).
-				Padding(0, 1),
-
-			Prompt: lipgloss.NewStyle().
-				Foreground(lipgloss.Color("208")).
-				Bold(true),
-
-			Result: lipgloss.NewStyle().
-				Foreground(lipgloss.Color("215")),
-
-			Error: lipgloss.NewStyle().
-				Foreground(lipgloss.Color("196")).
-				Bold(true),
-
-			Info: lipgloss.NewStyle().
-				Foreground(lipgloss.Color("173")).
-				Italic(true),
-
-			HelpText: lipgloss.NewStyle().
-				Foreground(lipgloss.Color("130")).
-				Italic(true),
-		},
-	},
-
-	"monochrome": {
-		Name: "Monochrome",
-		Styles: repl.Styles{
-			Title: lipgloss.NewStyle().
-				Bold(true).
-				Foreground(lipgloss.Color("15")).
-				Background(lipgloss.Color("238")).
-				Padding(0, 1),
-
-			Prompt: lipgloss.NewStyle().
-				Foreground(lipgloss.Color("250")).
-				Bold(true),
-
-			Result: lipgloss.NewStyle().
-				Foreground(lipgloss.Color("252")),
-
-			Error: lipgloss.NewStyle().
-				Foreground(lipgloss.Color("244")).
-				Bold(true),
-
-			Info: lipgloss.NewStyle().
-				Foreground(lipgloss.Color("246")).
-				Italic(true),
-
-			HelpText: lipgloss.NewStyle().
-				Foreground(lipgloss.Color("240")).
-				Italic(true),
-		},
-	},
-
-	"rainbow": {
-		Name: "Rainbow",
-		Styles: repl.Styles{
-			Title: lipgloss.NewStyle().
-				Bold(true).
-				Foreground(lipgloss.Color("15")).
-				Background(lipgloss.Color("90")).
-				Padding(0, 1),
-
-			Prompt: lipgloss.NewStyle().
-				Foreground(lipgloss.Color("196")).
-				Bold(true),
-
-			Result: lipgloss.NewStyle().
-				Foreground(lipgloss.Color("51")),
-
-			Error: lipgloss.NewStyle().
-				Foreground(lipgloss.Color("226")).
-				Bold(true),
-
-			Info: lipgloss.NewStyle().
-				Foreground(lipgloss.Color("207")).
-				Italic(true),
-
-			HelpText: lipgloss.NewStyle().
-				Foreground(lipgloss.Color("45")).
-				Italic(true),
-		},
-	},
-}
+// Custom theme data removed in timeline-centric example to focus on hotkeys and streaming output.
 
 // Theme switcher application
 type ThemeSwitcherApp struct {
-	repl         repl.Model
-	evaluator    *ThemeDemo
-	currentTheme string
-	themeList    []string
+    repl         *repl.Model
+    evaluator    *ThemeDemo
+    currentTheme string
 }
 
-func NewThemeSwitcherApp() *ThemeSwitcherApp {
-	evaluator := NewThemeDemo()
-
-	config := repl.Config{
-		Title:          "Theme Switcher Demo",
-		Placeholder:    "Try: 'demo', 'colors', 'rainbow', F1-F6 to switch themes",
-		Width:          100,
-		EnableHistory:  true,
-		MaxHistorySize: 200,
-	}
-
-	model := repl.NewModel(evaluator, config)
-
-	// Get all theme names
-	themeList := []string{"default", "dark", "light"}
-	for name := range customThemes {
-		themeList = append(themeList, name)
-	}
-
-	app := &ThemeSwitcherApp{
-		repl:         model,
-		evaluator:    evaluator,
-		currentTheme: "dark",
-		themeList:    themeList,
-	}
-
-	// Set initial theme
-	app.repl.SetTheme(repl.BuiltinThemes["dark"])
-
-	// Add theme switching commands
-	app.addThemeCommands()
-
-	return app
+// NewThemeSwitcherApp wires a pre-built REPL model and evaluator and adds F1-F9 hotkeys.
+func NewThemeSwitcherApp(model *repl.Model, evaluator *ThemeDemo) *ThemeSwitcherApp {
+    return &ThemeSwitcherApp{
+        repl:         model,
+        evaluator:    evaluator,
+        currentTheme: "dark",
+    }
 }
 
-func (app *ThemeSwitcherApp) addThemeCommands() {
-	// Add theme switching command
-	app.repl.AddCustomCommand("theme", func(args []string) tea.Cmd {
-		return func() tea.Msg {
-			if len(args) == 0 {
-				return repl.EvaluationCompleteMsg{
-					Input:  "/theme",
-					Output: fmt.Sprintf("Current theme: %s\nAvailable themes: %s", app.currentTheme, strings.Join(app.themeList, ", ")),
-					Error:  nil,
-				}
-			}
-
-			themeName := args[0]
-
-			// Check built-in themes
-			if theme, ok := repl.BuiltinThemes[themeName]; ok {
-				app.repl.SetTheme(theme)
-				app.currentTheme = themeName
-				app.evaluator.currentTheme = themeName
-				return repl.EvaluationCompleteMsg{
-					Input:  "/theme " + themeName,
-					Output: fmt.Sprintf("Switched to built-in theme: %s", themeName),
-					Error:  nil,
-				}
-			}
-
-			// Check custom themes
-			if theme, ok := customThemes[themeName]; ok {
-				app.repl.SetTheme(theme)
-				app.currentTheme = themeName
-				app.evaluator.currentTheme = themeName
-				return repl.EvaluationCompleteMsg{
-					Input:  "/theme " + themeName,
-					Output: fmt.Sprintf("Switched to custom theme: %s", themeName),
-					Error:  nil,
-				}
-			}
-
-			return repl.EvaluationCompleteMsg{
-				Input:  "/theme " + themeName,
-				Output: fmt.Sprintf("Theme '%s' not found. Available themes: %s", themeName, strings.Join(app.themeList, ", ")),
-				Error:  fmt.Errorf("theme not found"),
-			}
-		}
-	})
-
-	// Add theme list command
-	app.repl.AddCustomCommand("themes", func(args []string) tea.Cmd {
-		return func() tea.Msg {
-			var builtinThemes []string
-			for name := range repl.BuiltinThemes {
-				builtinThemes = append(builtinThemes, name)
-			}
-
-			var customThemeNames []string
-			for name := range customThemes {
-				customThemeNames = append(customThemeNames, name)
-			}
-
-			output := fmt.Sprintf("Built-in themes: %s\nCustom themes: %s\nCurrent theme: %s",
-				strings.Join(builtinThemes, ", "),
-				strings.Join(customThemeNames, ", "),
-				app.currentTheme)
-
-			return repl.EvaluationCompleteMsg{
-				Input:  "/themes",
-				Output: output,
-				Error:  nil,
-			}
-		}
-	})
-
-	// Add theme demo command
-	app.repl.AddCustomCommand("demo", func(args []string) tea.Cmd {
-		return func() tea.Msg {
-			return repl.EvaluationCompleteMsg{
-				Input:  "/demo",
-				Output: "This is a demonstration of the current theme!\nTry different themes to see how the styling changes.\nUse F1-F6 keys or /theme <name> to switch themes.",
-				Error:  nil,
-			}
-		}
-	})
-}
+// Note: no custom slash commands in this example; use evaluator outputs and F-keys.
 
 func (app *ThemeSwitcherApp) Init() tea.Cmd {
 	return app.repl.Init()
 }
 
 func (app *ThemeSwitcherApp) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
-	switch msg := msg.(type) {
-	case tea.KeyMsg:
-		switch msg.String() {
-		case "f1":
-			app.repl.SetTheme(repl.BuiltinThemes["default"])
-			app.currentTheme = "default"
-			app.evaluator.currentTheme = "default"
-			return app, nil
-		case "f2":
-			app.repl.SetTheme(repl.BuiltinThemes["dark"])
-			app.currentTheme = "dark"
-			app.evaluator.currentTheme = "dark"
-			return app, nil
-		case "f3":
-			app.repl.SetTheme(repl.BuiltinThemes["light"])
-			app.currentTheme = "light"
-			app.evaluator.currentTheme = "light"
-			return app, nil
-		case "f4":
-			app.repl.SetTheme(customThemes["cyberpunk"])
-			app.currentTheme = "cyberpunk"
-			app.evaluator.currentTheme = "cyberpunk"
-			return app, nil
-		case "f5":
-			app.repl.SetTheme(customThemes["ocean"])
-			app.currentTheme = "ocean"
-			app.evaluator.currentTheme = "ocean"
-			return app, nil
-		case "f6":
-			app.repl.SetTheme(customThemes["forest"])
-			app.currentTheme = "forest"
-			app.evaluator.currentTheme = "forest"
-			return app, nil
-		case "f7":
-			app.repl.SetTheme(customThemes["sunset"])
-			app.currentTheme = "sunset"
-			app.evaluator.currentTheme = "sunset"
-			return app, nil
-		case "f8":
-			app.repl.SetTheme(customThemes["monochrome"])
-			app.currentTheme = "monochrome"
-			app.evaluator.currentTheme = "monochrome"
-			return app, nil
-		case "f9":
-			app.repl.SetTheme(customThemes["rainbow"])
-			app.currentTheme = "rainbow"
-			app.evaluator.currentTheme = "rainbow"
-			return app, nil
-		}
-	}
+    switch msg := msg.(type) {
+    case tea.KeyMsg:
+        switch msg.String() {
+        case "f1":
+            app.currentTheme = "default"; app.evaluator.currentTheme = "default"; return app, nil
+        case "f2":
+            app.currentTheme = "dark"; app.evaluator.currentTheme = "dark"; return app, nil
+        case "f3":
+            app.currentTheme = "light"; app.evaluator.currentTheme = "light"; return app, nil
+        case "f4":
+            app.currentTheme = "cyberpunk"; app.evaluator.currentTheme = "cyberpunk"; return app, nil
+        case "f5":
+            app.currentTheme = "ocean"; app.evaluator.currentTheme = "ocean"; return app, nil
+        case "f6":
+            app.currentTheme = "forest"; app.evaluator.currentTheme = "forest"; return app, nil
+        case "f7":
+            app.currentTheme = "sunset"; app.evaluator.currentTheme = "sunset"; return app, nil
+        case "f8":
+            app.currentTheme = "monochrome"; app.evaluator.currentTheme = "monochrome"; return app, nil
+        case "f9":
+            app.currentTheme = "rainbow"; app.evaluator.currentTheme = "rainbow"; return app, nil
+        }
+    }
 
 	var cmd tea.Cmd
-	updatedModel, cmd := app.repl.Update(msg)
-	if replModel, ok := updatedModel.(repl.Model); ok {
-		app.repl = replModel
-	}
+    updatedModel, cmd := app.repl.Update(msg)
+    if replModel, ok := updatedModel.(*repl.Model); ok {
+        app.repl = replModel
+    }
 	return app, cmd
 }
 
@@ -450,9 +129,9 @@ func (app *ThemeSwitcherApp) View() string {
 	view := app.repl.View()
 
 	// Add theme information at the bottom
-	themeInfo := lipgloss.NewStyle().
-		Foreground(lipgloss.Color("243")).
-		Render(fmt.Sprintf("Current theme: %s | F1-F9: Quick theme switch | /theme <name>: Switch theme | /themes: List themes", app.currentTheme))
+    themeInfo := lipgloss.NewStyle().
+        Foreground(lipgloss.Color("243")).
+        Render(fmt.Sprintf("Current theme: %s | F1-F9: Quick theme switch | Commands: demo, colors, rainbow", app.currentTheme))
 
 	return lipgloss.JoinVertical(
 		lipgloss.Left,
@@ -466,14 +145,14 @@ func main() {
     // Silence logs for TUI
     logutil.InitTUILoggingToDiscard(zerolog.ErrorLevel)
 
-    // Simplified theme demo: run REPL with ThemeDemo evaluator via Watermill bus
+    // Theme demo: run REPL with ThemeDemo evaluator via Watermill bus
     evaluator := NewThemeDemo()
     config := repl.Config{
-        Title:                "Theme Demo (simplified)",
-        Placeholder:          "Type 'demo' or 'colors'",
-        Width:                100,
-        EnableHistory:        true,
-        MaxHistorySize:       200,
+        Title:          "Theme Demo",
+        Placeholder:    "Try: demo, colors, rainbow. Use F1-F9 to change theme label.",
+        Width:          100,
+        EnableHistory:  true,
+        MaxHistorySize: 200,
     }
 
     bus, err := eventbus.NewInMemoryBus()
@@ -481,7 +160,8 @@ func main() {
     repl.RegisterReplToTimelineTransformer(bus)
 
     model := repl.NewModel(evaluator, config, bus.Publisher)
-    p := tea.NewProgram(model, tea.WithAltScreen())
+    app := NewThemeSwitcherApp(model, evaluator)
+    p := tea.NewProgram(app, tea.WithAltScreen())
     timeline.RegisterUIForwarder(bus, p)
 
     ctx, cancel := context.WithCancel(context.Background())

--- a/examples/repl/custom-theme/main.go
+++ b/examples/repl/custom-theme/main.go
@@ -1,18 +1,18 @@
 package main
 
 import (
-    "context"
-    "fmt"
-    "log"
-    "strings"
+	"context"
+	"fmt"
+	"log"
+	"strings"
 
-    "github.com/charmbracelet/lipgloss"
-    tea "github.com/charmbracelet/bubbletea"
-    "github.com/go-go-golems/bobatea/pkg/eventbus"
-    "github.com/go-go-golems/bobatea/pkg/logutil"
-    "github.com/go-go-golems/bobatea/pkg/repl"
-    "github.com/go-go-golems/bobatea/pkg/timeline"
-    "github.com/rs/zerolog"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+	"github.com/go-go-golems/bobatea/pkg/eventbus"
+	"github.com/go-go-golems/bobatea/pkg/logutil"
+	"github.com/go-go-golems/bobatea/pkg/repl"
+	"github.com/go-go-golems/bobatea/pkg/timeline"
+	"github.com/rs/zerolog"
 )
 
 // ThemeDemo evaluator that demonstrates different themes
@@ -27,29 +27,29 @@ func NewThemeDemo() *ThemeDemo {
 }
 
 func (e *ThemeDemo) EvaluateStream(ctx context.Context, code string, emit func(repl.Event)) error {
-    code = strings.TrimSpace(code)
+	code = strings.TrimSpace(code)
 
-    if code == "" {
-        emit(repl.Event{Kind: repl.EventResultMarkdown, Props: map[string]any{"markdown": "Empty input"}})
-        return nil
-    }
+	if code == "" {
+		emit(repl.Event{Kind: repl.EventResultMarkdown, Props: map[string]any{"markdown": "Empty input"}})
+		return nil
+	}
 
-    // Demonstrate colorful output
-    switch code {
-    case "rainbow":
-        emit(repl.Event{Kind: repl.EventResultMarkdown, Props: map[string]any{"markdown": "🌈 Rainbow colors! 🌈"}})
-        return nil
-    case "colors":
-        emit(repl.Event{Kind: repl.EventResultMarkdown, Props: map[string]any{"markdown": "Red, Green, Blue, Yellow, Magenta, Cyan"}})
-        return nil
-    case "demo":
-        emit(repl.Event{Kind: repl.EventResultMarkdown, Props: map[string]any{"markdown": "This is a demonstration of themed output!\nTry different themes to see the styling change."}})
-        return nil
-    }
+	// Demonstrate colorful output
+	switch code {
+	case "rainbow":
+		emit(repl.Event{Kind: repl.EventResultMarkdown, Props: map[string]any{"markdown": "🌈 Rainbow colors! 🌈"}})
+		return nil
+	case "colors":
+		emit(repl.Event{Kind: repl.EventResultMarkdown, Props: map[string]any{"markdown": "Red, Green, Blue, Yellow, Magenta, Cyan"}})
+		return nil
+	case "demo":
+		emit(repl.Event{Kind: repl.EventResultMarkdown, Props: map[string]any{"markdown": "This is a demonstration of themed output!\nTry different themes to see the styling change."}})
+		return nil
+	}
 
-    // Default response
-    emit(repl.Event{Kind: repl.EventResultMarkdown, Props: map[string]any{"markdown": fmt.Sprintf("Current theme: %s | You said: %s", e.currentTheme, code)}})
-    return nil
+	// Default response
+	emit(repl.Event{Kind: repl.EventResultMarkdown, Props: map[string]any{"markdown": fmt.Sprintf("Current theme: %s | You said: %s", e.currentTheme, code)}})
+	return nil
 }
 
 func (e *ThemeDemo) GetPrompt() string {
@@ -72,18 +72,18 @@ func (e *ThemeDemo) GetFileExtension() string {
 
 // Theme switcher application
 type ThemeSwitcherApp struct {
-    repl         *repl.Model
-    evaluator    *ThemeDemo
-    currentTheme string
+	repl         *repl.Model
+	evaluator    *ThemeDemo
+	currentTheme string
 }
 
 // NewThemeSwitcherApp wires a pre-built REPL model and evaluator and adds F1-F9 hotkeys.
 func NewThemeSwitcherApp(model *repl.Model, evaluator *ThemeDemo) *ThemeSwitcherApp {
-    return &ThemeSwitcherApp{
-        repl:         model,
-        evaluator:    evaluator,
-        currentTheme: "dark",
-    }
+	return &ThemeSwitcherApp{
+		repl:         model,
+		evaluator:    evaluator,
+		currentTheme: "dark",
+	}
 }
 
 // Note: no custom slash commands in this example; use evaluator outputs and F-keys.
@@ -93,35 +93,53 @@ func (app *ThemeSwitcherApp) Init() tea.Cmd {
 }
 
 func (app *ThemeSwitcherApp) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
-    switch msg := msg.(type) {
-    case tea.KeyMsg:
-        switch msg.String() {
-        case "f1":
-            app.currentTheme = "default"; app.evaluator.currentTheme = "default"; return app, nil
-        case "f2":
-            app.currentTheme = "dark"; app.evaluator.currentTheme = "dark"; return app, nil
-        case "f3":
-            app.currentTheme = "light"; app.evaluator.currentTheme = "light"; return app, nil
-        case "f4":
-            app.currentTheme = "cyberpunk"; app.evaluator.currentTheme = "cyberpunk"; return app, nil
-        case "f5":
-            app.currentTheme = "ocean"; app.evaluator.currentTheme = "ocean"; return app, nil
-        case "f6":
-            app.currentTheme = "forest"; app.evaluator.currentTheme = "forest"; return app, nil
-        case "f7":
-            app.currentTheme = "sunset"; app.evaluator.currentTheme = "sunset"; return app, nil
-        case "f8":
-            app.currentTheme = "monochrome"; app.evaluator.currentTheme = "monochrome"; return app, nil
-        case "f9":
-            app.currentTheme = "rainbow"; app.evaluator.currentTheme = "rainbow"; return app, nil
-        }
-    }
+	switch msg := msg.(type) {
+	case tea.KeyMsg:
+		switch msg.String() {
+		case "f1":
+			app.currentTheme = "default"
+			app.evaluator.currentTheme = "default"
+			return app, nil
+		case "f2":
+			app.currentTheme = "dark"
+			app.evaluator.currentTheme = "dark"
+			return app, nil
+		case "f3":
+			app.currentTheme = "light"
+			app.evaluator.currentTheme = "light"
+			return app, nil
+		case "f4":
+			app.currentTheme = "cyberpunk"
+			app.evaluator.currentTheme = "cyberpunk"
+			return app, nil
+		case "f5":
+			app.currentTheme = "ocean"
+			app.evaluator.currentTheme = "ocean"
+			return app, nil
+		case "f6":
+			app.currentTheme = "forest"
+			app.evaluator.currentTheme = "forest"
+			return app, nil
+		case "f7":
+			app.currentTheme = "sunset"
+			app.evaluator.currentTheme = "sunset"
+			return app, nil
+		case "f8":
+			app.currentTheme = "monochrome"
+			app.evaluator.currentTheme = "monochrome"
+			return app, nil
+		case "f9":
+			app.currentTheme = "rainbow"
+			app.evaluator.currentTheme = "rainbow"
+			return app, nil
+		}
+	}
 
 	var cmd tea.Cmd
-    updatedModel, cmd := app.repl.Update(msg)
-    if replModel, ok := updatedModel.(*repl.Model); ok {
-        app.repl = replModel
-    }
+	updatedModel, cmd := app.repl.Update(msg)
+	if replModel, ok := updatedModel.(*repl.Model); ok {
+		app.repl = replModel
+	}
 	return app, cmd
 }
 
@@ -129,9 +147,9 @@ func (app *ThemeSwitcherApp) View() string {
 	view := app.repl.View()
 
 	// Add theme information at the bottom
-    themeInfo := lipgloss.NewStyle().
-        Foreground(lipgloss.Color("243")).
-        Render(fmt.Sprintf("Current theme: %s | F1-F9: Quick theme switch | Commands: demo, colors, rainbow", app.currentTheme))
+	themeInfo := lipgloss.NewStyle().
+		Foreground(lipgloss.Color("243")).
+		Render(fmt.Sprintf("Current theme: %s | F1-F9: Quick theme switch | Commands: demo, colors, rainbow", app.currentTheme))
 
 	return lipgloss.JoinVertical(
 		lipgloss.Left,
@@ -142,32 +160,36 @@ func (app *ThemeSwitcherApp) View() string {
 }
 
 func main() {
-    // Silence logs for TUI
-    logutil.InitTUILoggingToDiscard(zerolog.ErrorLevel)
+	// Silence logs for TUI
+	logutil.InitTUILoggingToDiscard(zerolog.ErrorLevel)
 
-    // Theme demo: run REPL with ThemeDemo evaluator via Watermill bus
-    evaluator := NewThemeDemo()
-    config := repl.Config{
-        Title:          "Theme Demo",
-        Placeholder:    "Try: demo, colors, rainbow. Use F1-F9 to change theme label.",
-        Width:          100,
-        EnableHistory:  true,
-        MaxHistorySize: 200,
-    }
+	// Theme demo: run REPL with ThemeDemo evaluator via Watermill bus
+	evaluator := NewThemeDemo()
+	config := repl.Config{
+		Title:          "Theme Demo",
+		Placeholder:    "Try: demo, colors, rainbow. Use F1-F9 to change theme label.",
+		Width:          100,
+		EnableHistory:  true,
+		MaxHistorySize: 200,
+	}
 
-    bus, err := eventbus.NewInMemoryBus()
-    if err != nil { log.Fatal(err) }
-    repl.RegisterReplToTimelineTransformer(bus)
+	bus, err := eventbus.NewInMemoryBus()
+	if err != nil {
+		log.Fatal(err)
+	}
+	repl.RegisterReplToTimelineTransformer(bus)
 
-    model := repl.NewModel(evaluator, config, bus.Publisher)
-    app := NewThemeSwitcherApp(model, evaluator)
-    p := tea.NewProgram(app, tea.WithAltScreen())
-    timeline.RegisterUIForwarder(bus, p)
+	model := repl.NewModel(evaluator, config, bus.Publisher)
+	app := NewThemeSwitcherApp(model, evaluator)
+	p := tea.NewProgram(app, tea.WithAltScreen())
+	timeline.RegisterUIForwarder(bus, p)
 
-    ctx, cancel := context.WithCancel(context.Background())
-    defer cancel()
-    errs := make(chan error, 2)
-    go func() { errs <- bus.Run(ctx) }()
-    go func() { _, e := p.Run(); cancel(); errs <- e }()
-    if e := <-errs; e != nil { log.Fatal(e) }
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	errs := make(chan error, 2)
+	go func() { errs <- bus.Run(ctx) }()
+	go func() { _, e := p.Run(); cancel(); errs <- e }()
+	if e := <-errs; e != nil {
+		log.Fatal(e)
+	}
 }

--- a/pkg/eventbus/eventbus.go
+++ b/pkg/eventbus/eventbus.go
@@ -1,56 +1,55 @@
 package eventbus
 
 import (
-    "context"
-    "sync"
+	"context"
+	"sync"
 
-    "github.com/ThreeDotsLabs/watermill"
-    "github.com/ThreeDotsLabs/watermill/message"
-    gochannel "github.com/ThreeDotsLabs/watermill/pubsub/gochannel"
+	"github.com/ThreeDotsLabs/watermill"
+	"github.com/ThreeDotsLabs/watermill/message"
+	gochannel "github.com/ThreeDotsLabs/watermill/pubsub/gochannel"
 )
 
 // Topics used by the REPL timeline bus.
 const (
-    TopicReplEvents = "repl.events"
-    TopicUIEntities = "ui.entities"
+	TopicReplEvents = "repl.events"
+	TopicUIEntities = "ui.entities"
 )
 
 // Bus wraps a Watermill in-memory router + pubsub.
 type Bus struct {
-    Router     *message.Router
-    Publisher  message.Publisher
-    Subscriber message.Subscriber
+	Router     *message.Router
+	Publisher  message.Publisher
+	Subscriber message.Subscriber
 
-    runOnce sync.Once
+	runOnce sync.Once
 }
 
 // NewInMemoryBus creates an in-memory Watermill router with gochannel pubsub.
 func NewInMemoryBus() (*Bus, error) {
-    logger := watermill.NewStdLogger(false, false)
-    pubsub := gochannel.NewGoChannel(gochannel.Config{OutputChannelBuffer: 1024}, logger)
-    r, err := message.NewRouter(message.RouterConfig{}, logger)
-    if err != nil {
-        return nil, err
-    }
-    return &Bus{Router: r, Publisher: pubsub, Subscriber: pubsub}, nil
+	logger := watermill.NewStdLogger(false, false)
+	pubsub := gochannel.NewGoChannel(gochannel.Config{OutputChannelBuffer: 1024}, logger)
+	r, err := message.NewRouter(message.RouterConfig{}, logger)
+	if err != nil {
+		return nil, err
+	}
+	return &Bus{Router: r, Publisher: pubsub, Subscriber: pubsub}, nil
 }
 
 // AddHandler subscribes to a topic and handles messages (no publishing from handler by default).
 func (b *Bus) AddHandler(name, topic string, handler func(*message.Message) error) {
-    b.Router.AddNoPublisherHandler(name, topic, b.Subscriber, handler)
+	b.Router.AddNoPublisherHandler(name, topic, b.Subscriber, handler)
 }
 
 // Run starts the router until ctx is done.
 func (b *Bus) Run(ctx context.Context) error {
-    var err error
-    b.runOnce.Do(func() {
-        go func() {
-            // Router blocks; stop when context cancelled
-            <-ctx.Done()
-            _ = b.Router.Close()
-        }()
-        err = b.Router.Run(ctx)
-    })
-    return err
+	var err error
+	b.runOnce.Do(func() {
+		go func() {
+			// Router blocks; stop when context cancelled
+			<-ctx.Done()
+			_ = b.Router.Close()
+		}()
+		err = b.Router.Run(ctx)
+	})
+	return err
 }
-

--- a/pkg/eventbus/eventbus.go
+++ b/pkg/eventbus/eventbus.go
@@ -1,0 +1,56 @@
+package eventbus
+
+import (
+    "context"
+    "sync"
+
+    "github.com/ThreeDotsLabs/watermill"
+    "github.com/ThreeDotsLabs/watermill/message"
+    gochannel "github.com/ThreeDotsLabs/watermill/pubsub/gochannel"
+)
+
+// Topics used by the REPL timeline bus.
+const (
+    TopicReplEvents = "repl.events"
+    TopicUIEntities = "ui.entities"
+)
+
+// Bus wraps a Watermill in-memory router + pubsub.
+type Bus struct {
+    Router     *message.Router
+    Publisher  message.Publisher
+    Subscriber message.Subscriber
+
+    runOnce sync.Once
+}
+
+// NewInMemoryBus creates an in-memory Watermill router with gochannel pubsub.
+func NewInMemoryBus() (*Bus, error) {
+    logger := watermill.NewStdLogger(false, false)
+    pubsub := gochannel.NewGoChannel(gochannel.Config{OutputChannelBuffer: 1024}, logger)
+    r, err := message.NewRouter(message.RouterConfig{}, logger)
+    if err != nil {
+        return nil, err
+    }
+    return &Bus{Router: r, Publisher: pubsub, Subscriber: pubsub}, nil
+}
+
+// AddHandler subscribes to a topic and handles messages (no publishing from handler by default).
+func (b *Bus) AddHandler(name, topic string, handler func(*message.Message) error) {
+    b.Router.AddNoPublisherHandler(name, topic, b.Subscriber, handler)
+}
+
+// Run starts the router until ctx is done.
+func (b *Bus) Run(ctx context.Context) error {
+    var err error
+    b.runOnce.Do(func() {
+        go func() {
+            // Router blocks; stop when context cancelled
+            <-ctx.Done()
+            _ = b.Router.Close()
+        }()
+        err = b.Router.Run(ctx)
+    })
+    return err
+}
+

--- a/pkg/logutil/logutil.go
+++ b/pkg/logutil/logutil.go
@@ -1,30 +1,29 @@
 package logutil
 
 import (
-    "io"
-    "os"
+	"io"
+	"os"
 
-    "github.com/rs/zerolog"
-    zlog "github.com/rs/zerolog/log"
+	"github.com/rs/zerolog"
+	zlog "github.com/rs/zerolog/log"
 )
 
 // InitTUILoggingToDiscard configures zerolog to a given level and discards all output,
 // avoiding interference with TUI stdout.
 func InitTUILoggingToDiscard(level zerolog.Level) {
-    zerolog.SetGlobalLevel(level)
-    zlog.Logger = zerolog.New(io.Discard)
+	zerolog.SetGlobalLevel(level)
+	zlog.Logger = zerolog.New(io.Discard)
 }
 
 // InitTUILoggingToFile writes logs to a file using a console writer without color.
 // If file open fails, it falls back to discarding output.
 func InitTUILoggingToFile(level zerolog.Level, path string) {
-    zerolog.SetGlobalLevel(level)
-    f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644) // #nosec G302
-    if err != nil {
-        zlog.Logger = zerolog.New(io.Discard)
-        return
-    }
-    cw := zerolog.ConsoleWriter{Out: f, NoColor: true}
-    zlog.Logger = zerolog.New(cw).With().Timestamp().Logger()
+	zerolog.SetGlobalLevel(level)
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644) // #nosec G302
+	if err != nil {
+		zlog.Logger = zerolog.New(io.Discard)
+		return
+	}
+	cw := zerolog.ConsoleWriter{Out: f, NoColor: true}
+	zlog.Logger = zerolog.New(cw).With().Timestamp().Logger()
 }
-

--- a/pkg/logutil/logutil.go
+++ b/pkg/logutil/logutil.go
@@ -1,0 +1,30 @@
+package logutil
+
+import (
+    "io"
+    "os"
+
+    "github.com/rs/zerolog"
+    zlog "github.com/rs/zerolog/log"
+)
+
+// InitTUILoggingToDiscard configures zerolog to a given level and discards all output,
+// avoiding interference with TUI stdout.
+func InitTUILoggingToDiscard(level zerolog.Level) {
+    zerolog.SetGlobalLevel(level)
+    zlog.Logger = zerolog.New(io.Discard)
+}
+
+// InitTUILoggingToFile writes logs to a file using a console writer without color.
+// If file open fails, it falls back to discarding output.
+func InitTUILoggingToFile(level zerolog.Level, path string) {
+    zerolog.SetGlobalLevel(level)
+    f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644) // #nosec G302
+    if err != nil {
+        zlog.Logger = zerolog.New(io.Discard)
+        return
+    }
+    cw := zerolog.ConsoleWriter{Out: f, NoColor: true}
+    zlog.Logger = zerolog.New(cw).With().Timestamp().Logger()
+}
+

--- a/pkg/repl/bridge.go
+++ b/pkg/repl/bridge.go
@@ -1,70 +1,75 @@
 package repl
 
 import (
-    "time"
+	"time"
 
-    "github.com/go-go-golems/bobatea/pkg/timeline"
-    "github.com/rs/zerolog/log"
+	"github.com/go-go-golems/bobatea/pkg/timeline"
+	"github.com/rs/zerolog/log"
 )
 
 // Bridge maps Evaluator events to timeline lifecycle messages via the Shell wrapper
 // to ensure viewport refresh semantics are consistent.
 type Bridge struct {
-    sh    *timeline.Shell
-    clock func() time.Time
+	sh    *timeline.Shell
+	clock func() time.Time
 }
 
 func NewBridge(sh *timeline.Shell) *Bridge {
-    return &Bridge{sh: sh, clock: time.Now}
+	return &Bridge{sh: sh, clock: time.Now}
 }
 
 func (b *Bridge) NewTurnID(seq int) string {
-    return time.Now().Format("20060102-150405.000000000") + ":" + itoa(seq)
+	return time.Now().Format("20060102-150405.000000000") + ":" + itoa(seq)
 }
 
 func (b *Bridge) Emit(turnID, local, kind string, props map[string]any) timeline.EntityID {
-    id := timeline.EntityID{TurnID: turnID, LocalID: local, Kind: kind}
-    start := time.Now()
-    b.sh.OnCreated(timeline.UIEntityCreated{
-        ID:        id,
-        Renderer:  timeline.RendererDescriptor{Kind: kind},
-        Props:     props,
-        StartedAt: b.clock(),
-    })
-    dur := time.Since(start)
-    log.Debug().Str("op", "emit").Str("turn", turnID).Str("local", local).Str("kind", kind).Dur("dur", dur).Msg("timeline entity created and view refreshed")
-    return id
+	id := timeline.EntityID{TurnID: turnID, LocalID: local, Kind: kind}
+	start := time.Now()
+	b.sh.OnCreated(timeline.UIEntityCreated{
+		ID:        id,
+		Renderer:  timeline.RendererDescriptor{Kind: kind},
+		Props:     props,
+		StartedAt: b.clock(),
+	})
+	dur := time.Since(start)
+	log.Debug().Str("op", "emit").Str("turn", turnID).Str("local", local).Str("kind", kind).Dur("dur", dur).Msg("timeline entity created and view refreshed")
+	return id
 }
 
 func (b *Bridge) Patch(id timeline.EntityID, patch map[string]any) {
-    start := time.Now()
-    b.sh.OnUpdated(timeline.UIEntityUpdated{ID: id, Patch: patch, Version: time.Now().UnixNano(), UpdatedAt: b.clock()})
-    dur := time.Since(start)
-    log.Debug().Str("op", "patch").Str("kind", id.Kind).Str("turn", id.TurnID).Str("local", id.LocalID).Dur("dur", dur).Int("patch_keys", len(patch)).Msg("timeline entity patched and view refreshed")
+	start := time.Now()
+	b.sh.OnUpdated(timeline.UIEntityUpdated{ID: id, Patch: patch, Version: time.Now().UnixNano(), UpdatedAt: b.clock()})
+	dur := time.Since(start)
+	log.Debug().Str("op", "patch").Str("kind", id.Kind).Str("turn", id.TurnID).Str("local", id.LocalID).Dur("dur", dur).Int("patch_keys", len(patch)).Msg("timeline entity patched and view refreshed")
 }
 
 func (b *Bridge) Complete(id timeline.EntityID, result map[string]any) {
-    start := time.Now()
-    b.sh.OnCompleted(timeline.UIEntityCompleted{ID: id, Result: result})
-    dur := time.Since(start)
-    log.Debug().Str("op", "complete").Str("kind", id.Kind).Str("turn", id.TurnID).Str("local", id.LocalID).Dur("dur", dur).Msg("timeline entity completed and view refreshed")
+	start := time.Now()
+	b.sh.OnCompleted(timeline.UIEntityCompleted{ID: id, Result: result})
+	dur := time.Since(start)
+	log.Debug().Str("op", "complete").Str("kind", id.Kind).Str("turn", id.TurnID).Str("local", id.LocalID).Dur("dur", dur).Msg("timeline entity completed and view refreshed")
 }
 
 func itoa(i int) string {
-    // small, allocation-free int to string for small numbers
-    if i == 0 { return "0" }
-    neg := false
-    if i < 0 { neg = true; i = -i }
-    var buf [20]byte
-    n := len(buf)
-    for i > 0 {
-        n--
-        buf[n] = byte('0' + (i % 10))
-        i /= 10
-    }
-    if neg { n--; buf[n] = '-' }
-    return string(buf[n:])
+	// small, allocation-free int to string for small numbers
+	if i == 0 {
+		return "0"
+	}
+	neg := false
+	if i < 0 {
+		neg = true
+		i = -i
+	}
+	var buf [20]byte
+	n := len(buf)
+	for i > 0 {
+		n--
+		buf[n] = byte('0' + (i % 10))
+		i /= 10
+	}
+	if neg {
+		n--
+		buf[n] = '-'
+	}
+	return string(buf[n:])
 }
-
-// Expose for reuse by REPL model without export
-func bridgeItoa(i int) string { return itoa(i) }

--- a/pkg/repl/bridge.go
+++ b/pkg/repl/bridge.go
@@ -1,0 +1,70 @@
+package repl
+
+import (
+    "time"
+
+    "github.com/go-go-golems/bobatea/pkg/timeline"
+    "github.com/rs/zerolog/log"
+)
+
+// Bridge maps Evaluator events to timeline lifecycle messages via the Shell wrapper
+// to ensure viewport refresh semantics are consistent.
+type Bridge struct {
+    sh    *timeline.Shell
+    clock func() time.Time
+}
+
+func NewBridge(sh *timeline.Shell) *Bridge {
+    return &Bridge{sh: sh, clock: time.Now}
+}
+
+func (b *Bridge) NewTurnID(seq int) string {
+    return time.Now().Format("20060102-150405.000000000") + ":" + itoa(seq)
+}
+
+func (b *Bridge) Emit(turnID, local, kind string, props map[string]any) timeline.EntityID {
+    id := timeline.EntityID{TurnID: turnID, LocalID: local, Kind: kind}
+    start := time.Now()
+    b.sh.OnCreated(timeline.UIEntityCreated{
+        ID:        id,
+        Renderer:  timeline.RendererDescriptor{Kind: kind},
+        Props:     props,
+        StartedAt: b.clock(),
+    })
+    dur := time.Since(start)
+    log.Debug().Str("op", "emit").Str("turn", turnID).Str("local", local).Str("kind", kind).Dur("dur", dur).Msg("timeline entity created and view refreshed")
+    return id
+}
+
+func (b *Bridge) Patch(id timeline.EntityID, patch map[string]any) {
+    start := time.Now()
+    b.sh.OnUpdated(timeline.UIEntityUpdated{ID: id, Patch: patch, Version: time.Now().UnixNano(), UpdatedAt: b.clock()})
+    dur := time.Since(start)
+    log.Debug().Str("op", "patch").Str("kind", id.Kind).Str("turn", id.TurnID).Str("local", id.LocalID).Dur("dur", dur).Int("patch_keys", len(patch)).Msg("timeline entity patched and view refreshed")
+}
+
+func (b *Bridge) Complete(id timeline.EntityID, result map[string]any) {
+    start := time.Now()
+    b.sh.OnCompleted(timeline.UIEntityCompleted{ID: id, Result: result})
+    dur := time.Since(start)
+    log.Debug().Str("op", "complete").Str("kind", id.Kind).Str("turn", id.TurnID).Str("local", id.LocalID).Dur("dur", dur).Msg("timeline entity completed and view refreshed")
+}
+
+func itoa(i int) string {
+    // small, allocation-free int to string for small numbers
+    if i == 0 { return "0" }
+    neg := false
+    if i < 0 { neg = true; i = -i }
+    var buf [20]byte
+    n := len(buf)
+    for i > 0 {
+        n--
+        buf[n] = byte('0' + (i % 10))
+        i /= 10
+    }
+    if neg { n--; buf[n] = '-' }
+    return string(buf[n:])
+}
+
+// Expose for reuse by REPL model without export
+func bridgeItoa(i int) string { return itoa(i) }

--- a/pkg/repl/config.go
+++ b/pkg/repl/config.go
@@ -2,27 +2,26 @@ package repl
 
 // Config holds REPL shell configuration.
 type Config struct {
-    Title                string
-    Prompt               string
-    Placeholder          string
-    Width                int
-    StartMultiline       bool
-    EnableExternalEditor bool
-    EnableHistory        bool
-    MaxHistorySize       int
+	Title                string
+	Prompt               string
+	Placeholder          string
+	Width                int
+	StartMultiline       bool
+	EnableExternalEditor bool
+	EnableHistory        bool
+	MaxHistorySize       int
 }
 
 // DefaultConfig returns a sensible default configuration.
 func DefaultConfig() Config {
-    return Config{
-        Title:                "REPL",
-        Prompt:               "> ",
-        Placeholder:          "Enter code or /command",
-        Width:                80,
-        StartMultiline:       false,
-        EnableExternalEditor: false,
-        EnableHistory:        true,
-        MaxHistorySize:       1000,
-    }
+	return Config{
+		Title:                "REPL",
+		Prompt:               "> ",
+		Placeholder:          "Enter code or /command",
+		Width:                80,
+		StartMultiline:       false,
+		EnableExternalEditor: false,
+		EnableHistory:        true,
+		MaxHistorySize:       1000,
+	}
 }
-

--- a/pkg/repl/config.go
+++ b/pkg/repl/config.go
@@ -1,0 +1,28 @@
+package repl
+
+// Config holds REPL shell configuration.
+type Config struct {
+    Title                string
+    Prompt               string
+    Placeholder          string
+    Width                int
+    StartMultiline       bool
+    EnableExternalEditor bool
+    EnableHistory        bool
+    MaxHistorySize       int
+}
+
+// DefaultConfig returns a sensible default configuration.
+func DefaultConfig() Config {
+    return Config{
+        Title:                "REPL",
+        Prompt:               "> ",
+        Placeholder:          "Enter code or /command",
+        Width:                80,
+        StartMultiline:       false,
+        EnableExternalEditor: false,
+        EnableHistory:        true,
+        MaxHistorySize:       1000,
+    }
+}
+

--- a/pkg/repl/evaluator.go
+++ b/pkg/repl/evaluator.go
@@ -10,8 +10,8 @@ const (
 	EventResultMarkdown EventKind = "repl_result_markdown" // props: markdown|string in "markdown" or "text"
 	EventStdout         EventKind = "repl_stdout"          // props: append|string or text
 	EventStderr         EventKind = "repl_stderr"          // props: append|string or text, is_error=true
-	EventLog            EventKind = "repl_log"              // props: level, message, metadata(optional), fields(optional)
-	EventStructuredLog  EventKind = "repl_structured_log"   // props: level, message(optional), data|metadata|fields
+	EventLog            EventKind = "repl_log"             // props: level, message, metadata(optional), fields(optional)
+	EventStructuredLog  EventKind = "repl_structured_log"  // props: level, message(optional), data|metadata|fields
 	EventToolCalls      EventKind = "repl_tool_calls"
 	EventProgress       EventKind = "repl_progress"
 	EventPerf           EventKind = "repl_perf"

--- a/pkg/repl/evaluator.go
+++ b/pkg/repl/evaluator.go
@@ -1,55 +1,38 @@
 package repl
 
-import (
-	"context"
+import "context"
+
+// EventKind enumerates structured output kinds for the timeline.
+type EventKind string
+
+const (
+    EventInput          EventKind = "repl_input"          // recommended to be emitted by REPL shell
+    EventResultMarkdown EventKind = "repl_result_markdown" // props: markdown|string in "markdown" or "text"
+    EventStdout         EventKind = "repl_stdout"          // props: append|string or text
+    EventStderr         EventKind = "repl_stderr"          // props: append|string or text, is_error=true
+    EventToolCalls      EventKind = "repl_tool_calls"
+    EventProgress       EventKind = "repl_progress"
+    EventPerf           EventKind = "repl_perf"
+    EventTable          EventKind = "repl_table"
+    EventDiff           EventKind = "repl_diff"
+    EventShellCmd       EventKind = "repl_shell_cmd"
+    EventInspector      EventKind = "repl_inspector"
 )
 
-// Evaluator represents the interface for pluggable evaluators
+// Event carries a semantic payload for the UI.
+type Event struct {
+    Kind  EventKind
+    Props map[string]any
+}
+
+// Evaluator executes code and streams events.
+// Errors should be represented as events too (e.g., stderr or result with error annotation),
+// with the returned error used for terminal failures.
 type Evaluator interface {
-	// Evaluate executes the given code and returns the result
-	Evaluate(ctx context.Context, code string) (string, error)
-
-	// GetPrompt returns the prompt string for this evaluator
-	GetPrompt() string
-
-	// GetName returns the name of this evaluator (for display)
-	GetName() string
-
-	// SupportsMultiline returns true if this evaluator supports multiline input
-	SupportsMultiline() bool
-
-	// GetFileExtension returns the file extension for external editor
-	GetFileExtension() string
+    EvaluateStream(ctx context.Context, code string, emit func(Event)) error
+    GetPrompt() string
+    GetName() string
+    SupportsMultiline() bool
+    GetFileExtension() string
 }
 
-// EvaluatorResult represents the result of an evaluation
-type EvaluatorResult struct {
-	Output string
-	Error  error
-}
-
-// Config holds configuration for the REPL
-type Config struct {
-	Title                string
-	Prompt               string
-	Placeholder          string
-	Width                int
-	StartMultiline       bool
-	EnableExternalEditor bool
-	EnableHistory        bool
-	MaxHistorySize       int
-}
-
-// DefaultConfig returns a default configuration
-func DefaultConfig() Config {
-	return Config{
-		Title:                "REPL",
-		Prompt:               "> ",
-		Placeholder:          "Enter code or /command",
-		Width:                80,
-		StartMultiline:       false,
-		EnableExternalEditor: true,
-		EnableHistory:        true,
-		MaxHistorySize:       1000,
-	}
-}

--- a/pkg/repl/evaluator.go
+++ b/pkg/repl/evaluator.go
@@ -6,33 +6,34 @@ import "context"
 type EventKind string
 
 const (
-    EventInput          EventKind = "repl_input"          // recommended to be emitted by REPL shell
-    EventResultMarkdown EventKind = "repl_result_markdown" // props: markdown|string in "markdown" or "text"
-    EventStdout         EventKind = "repl_stdout"          // props: append|string or text
-    EventStderr         EventKind = "repl_stderr"          // props: append|string or text, is_error=true
-    EventToolCalls      EventKind = "repl_tool_calls"
-    EventProgress       EventKind = "repl_progress"
-    EventPerf           EventKind = "repl_perf"
-    EventTable          EventKind = "repl_table"
-    EventDiff           EventKind = "repl_diff"
-    EventShellCmd       EventKind = "repl_shell_cmd"
-    EventInspector      EventKind = "repl_inspector"
+	EventInput          EventKind = "repl_input"           // recommended to be emitted by REPL shell
+	EventResultMarkdown EventKind = "repl_result_markdown" // props: markdown|string in "markdown" or "text"
+	EventStdout         EventKind = "repl_stdout"          // props: append|string or text
+	EventStderr         EventKind = "repl_stderr"          // props: append|string or text, is_error=true
+	EventLog            EventKind = "repl_log"              // props: level, message, metadata(optional), fields(optional)
+	EventStructuredLog  EventKind = "repl_structured_log"   // props: level, message(optional), data|metadata|fields
+	EventToolCalls      EventKind = "repl_tool_calls"
+	EventProgress       EventKind = "repl_progress"
+	EventPerf           EventKind = "repl_perf"
+	EventTable          EventKind = "repl_table"
+	EventDiff           EventKind = "repl_diff"
+	EventShellCmd       EventKind = "repl_shell_cmd"
+	EventInspector      EventKind = "repl_inspector"
 )
 
 // Event carries a semantic payload for the UI.
 type Event struct {
-    Kind  EventKind
-    Props map[string]any
+	Kind  EventKind
+	Props map[string]any
 }
 
 // Evaluator executes code and streams events.
 // Errors should be represented as events too (e.g., stderr or result with error annotation),
 // with the returned error used for terminal failures.
 type Evaluator interface {
-    EvaluateStream(ctx context.Context, code string, emit func(Event)) error
-    GetPrompt() string
-    GetName() string
-    SupportsMultiline() bool
-    GetFileExtension() string
+	EvaluateStream(ctx context.Context, code string, emit func(Event)) error
+	GetPrompt() string
+	GetName() string
+	SupportsMultiline() bool
+	GetFileExtension() string
 }
-

--- a/pkg/repl/evaluators/javascript/evaluator.go
+++ b/pkg/repl/evaluators/javascript/evaluator.go
@@ -150,6 +150,17 @@ func (e *Evaluator) Evaluate(ctx context.Context, code string) (string, error) {
 	return output, nil
 }
 
+// EvaluateStream adapts Evaluate to the streaming interface used by the timeline-based REPL.
+func (e *Evaluator) EvaluateStream(ctx context.Context, code string, emit func(repl.Event)) error {
+	out, err := e.Evaluate(ctx, code)
+	if err != nil {
+		emit(repl.Event{Kind: repl.EventResultMarkdown, Props: map[string]any{"markdown": fmt.Sprintf("Error: %v", err)}})
+		return nil
+	}
+	emit(repl.Event{Kind: repl.EventResultMarkdown, Props: map[string]any{"markdown": out}})
+	return nil
+}
+
 // GetPrompt returns the prompt string for JavaScript evaluation
 func (e *Evaluator) GetPrompt() string {
 	return "js>"

--- a/pkg/repl/example_evaluator.go
+++ b/pkg/repl/example_evaluator.go
@@ -44,6 +44,17 @@ func (e *ExampleEvaluator) Evaluate(ctx context.Context, code string) (string, e
 	return fmt.Sprintf("You typed: %s", code), nil
 }
 
+// EvaluateStream adapts Evaluate to the streaming interface expected by the REPL timeline.
+func (e *ExampleEvaluator) EvaluateStream(ctx context.Context, code string, emit func(Event)) error {
+	out, err := e.Evaluate(ctx, code)
+	if err != nil {
+		emit(Event{Kind: EventResultMarkdown, Props: map[string]any{"markdown": fmt.Sprintf("Error: %v", err)}})
+		return nil
+	}
+	emit(Event{Kind: EventResultMarkdown, Props: map[string]any{"markdown": out}})
+	return nil
+}
+
 // GetPrompt returns the prompt string
 func (e *ExampleEvaluator) GetPrompt() string {
 	return "example> "

--- a/pkg/repl/messages.go
+++ b/pkg/repl/messages.go
@@ -2,9 +2,9 @@ package repl
 
 // EvaluationCompleteMsg is sent when evaluation is complete
 type EvaluationCompleteMsg struct {
-    Input  string
-    Output string
-    Error  error
+	Input  string
+	Output string
+	Error  error
 }
 
 // HistoryNavigationMsg is sent when history navigation occurs
@@ -37,12 +37,6 @@ type QuitMsg struct{}
 
 // SlashCommandMsg is sent when a slash command is executed
 type SlashCommandMsg struct {
-    Command string
-    Args    []string
-}
-
-// New messages for streaming evaluator bridge
-// Note: these are also declared in model.go for internal usage but kept here for completeness.
-type _ReplEventMsg struct { // unused placeholder to avoid breaking external imports
-    _ string
+	Command string
+	Args    []string
 }

--- a/pkg/repl/messages.go
+++ b/pkg/repl/messages.go
@@ -2,9 +2,9 @@ package repl
 
 // EvaluationCompleteMsg is sent when evaluation is complete
 type EvaluationCompleteMsg struct {
-	Input  string
-	Output string
-	Error  error
+    Input  string
+    Output string
+    Error  error
 }
 
 // HistoryNavigationMsg is sent when history navigation occurs
@@ -37,6 +37,12 @@ type QuitMsg struct{}
 
 // SlashCommandMsg is sent when a slash command is executed
 type SlashCommandMsg struct {
-	Command string
-	Args    []string
+    Command string
+    Args    []string
+}
+
+// New messages for streaming evaluator bridge
+// Note: these are also declared in model.go for internal usage but kept here for completeness.
+type _ReplEventMsg struct { // unused placeholder to avoid breaking external imports
+    _ string
 }

--- a/pkg/repl/model.go
+++ b/pkg/repl/model.go
@@ -156,9 +156,11 @@ func (m *Model) updateInput(k tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m, tea.Quit
 	}
 	switch k.String() {
-	case "tab":
-		m.focus = "timeline"
-		return m, nil
+    case "tab":
+        m.focus = "timeline"
+        m.textInput.Blur()
+        m.sh.SetSelectionVisible(true)
+        return m, nil
 	case "enter":
 		input := m.textInput.Value()
 		if strings.TrimSpace(input) == "" {
@@ -190,10 +192,12 @@ func (m *Model) updateInput(k tea.KeyMsg) (tea.Model, tea.Cmd) {
 }
 
 func (m *Model) updateTimeline(k tea.KeyMsg) (tea.Model, tea.Cmd) {
-	switch k.String() {
-	case "tab":
-		m.focus = "input"
-		return m, nil
+    switch k.String() {
+    case "tab":
+        m.focus = "input"
+        m.textInput.Focus()
+        m.sh.SetSelectionVisible(false)
+        return m, nil
 	case "up":
 		m.sh.SelectPrev()
 		return m, nil
@@ -228,8 +232,12 @@ func (m *Model) View() string {
 	// timeline view (viewport-wrapped)
 	b.WriteString(m.sh.View())
 	b.WriteString("\n")
-	// input
-	b.WriteString(m.textInput.View())
+    // input (dim when in selection mode)
+    inputView := m.textInput.View()
+    if m.focus == "timeline" {
+        inputView = m.styles.HelpText.Render(inputView)
+    }
+    b.WriteString(inputView)
 	b.WriteString("\n")
 	// help
 	help := "TAB: switch focus | Enter: submit | Up/Down: history/selection | c: copy code | y: copy text | Ctrl+C: quit"

--- a/pkg/repl/model.go
+++ b/pkg/repl/model.go
@@ -61,10 +61,10 @@ func NewModel(evaluator Evaluator, config Config, pub message.Publisher) *Model 
 	reg := timeline.NewRegistry()
 	// Register base widgets
 	reg.RegisterModelFactory(renderers.TextFactory{})
-    reg.RegisterModelFactory(renderers.NewMarkdownFactory())
+	reg.RegisterModelFactory(renderers.NewMarkdownFactory())
 	reg.RegisterModelFactory(renderers.StructuredDataFactory{})
-    reg.RegisterModelFactory(renderers.LogEventFactory{})
-    reg.RegisterModelFactory(renderers.StructuredLogEventFactory{})
+	reg.RegisterModelFactory(renderers.LogEventFactory{})
+	reg.RegisterModelFactory(renderers.StructuredLogEventFactory{})
 
 	sh := timeline.NewShell(reg)
 

--- a/pkg/repl/model.go
+++ b/pkg/repl/model.go
@@ -1,263 +1,303 @@
 package repl
 
 import (
-    "context"
-    "encoding/json"
-    "fmt"
-    "strings"
-    "time"
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
 
-    "github.com/ThreeDotsLabs/watermill"
-    "github.com/ThreeDotsLabs/watermill/message"
-    "github.com/charmbracelet/bubbles/textinput"
-    tea "github.com/charmbracelet/bubbletea"
-    "github.com/go-go-golems/bobatea/pkg/eventbus"
-    "github.com/go-go-golems/bobatea/pkg/timeline"
-    renderers "github.com/go-go-golems/bobatea/pkg/timeline/renderers"
+	"github.com/ThreeDotsLabs/watermill"
+	"github.com/ThreeDotsLabs/watermill/message"
+	"github.com/charmbracelet/bubbles/cursor"
+	"github.com/charmbracelet/bubbles/textinput"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/go-go-golems/bobatea/pkg/eventbus"
+	"github.com/go-go-golems/bobatea/pkg/timeline"
+	renderers "github.com/go-go-golems/bobatea/pkg/timeline/renderers"
+	"github.com/rs/zerolog/log"
 )
 
 // Model is a timeline-first REPL shell: timeline transcript + input line.
 type Model struct {
-    evaluator Evaluator
-    config    Config
-    styles    Styles
+	evaluator Evaluator
+	config    Config
+	styles    Styles
 
-    // input & history
-    history   *History
-    textInput textinput.Model
-    multiline bool
-    lines     []string
+	// input & history
+	history   *History
+	textInput textinput.Model
+	multiline bool
+	lines     []string
 
-    // layout
-    width, height int
+	// layout
+	width, height int
 
-    // timeline shell (viewport + controller)
-    reg   *timeline.Registry
-    sh    *timeline.Shell
-    focus string // "input" or "timeline"
+	// timeline shell (viewport + controller)
+	reg   *timeline.Registry
+	sh    *timeline.Shell
+	focus string // "input" or "timeline"
 
-    // bus publisher
-    pub message.Publisher
-    turnSeq int
+	// bus publisher
+	pub     message.Publisher
+	turnSeq int
 
-    // refresh scheduling
-    refreshPending   bool
-    refreshScheduled bool
+	// refresh scheduling
+	refreshPending   bool
+	refreshScheduled bool
 }
 
 // NewModel constructs a new REPL shell with timeline transcript.
 func NewModel(evaluator Evaluator, config Config, pub message.Publisher) *Model {
-    if config.Prompt == "" {
-        config.Prompt = evaluator.GetPrompt()
-    }
-    ti := textinput.New()
-    ti.Prompt = config.Prompt
-    ti.Placeholder = config.Placeholder
-    ti.Focus()
-    ti.Width = max(10, config.Width-10)
+	if config.Prompt == "" {
+		config.Prompt = evaluator.GetPrompt()
+	}
+	ti := textinput.New()
+	ti.Prompt = config.Prompt
+	ti.Placeholder = config.Placeholder
+	ti.Focus()
+	ti.Width = max(10, config.Width-10)
 
-    reg := timeline.NewRegistry()
-    // Register base widgets
-    reg.RegisterModelFactory(renderers.TextFactory{})
-    reg.RegisterModelFactory(renderers.MarkdownFactory{})
-    reg.RegisterModelFactory(renderers.StructuredDataFactory{})
+	reg := timeline.NewRegistry()
+	// Register base widgets
+	reg.RegisterModelFactory(renderers.TextFactory{})
+    reg.RegisterModelFactory(renderers.NewMarkdownFactory())
+	reg.RegisterModelFactory(renderers.StructuredDataFactory{})
 
-    sh := timeline.NewShell(reg)
+	sh := timeline.NewShell(reg)
 
-    return &Model{
-        evaluator: evaluator,
-        config:    config,
-        styles:    DefaultStyles(),
-        history:   NewHistory(config.MaxHistorySize),
-        textInput: ti,
-        multiline: config.StartMultiline,
-        lines:     []string{},
-        width:     config.Width,
-        reg:       reg,
-        sh:        sh,
-        focus:     "input",
-        pub:       pub,
-    }
+	return &Model{
+		evaluator: evaluator,
+		config:    config,
+		styles:    DefaultStyles(),
+		history:   NewHistory(config.MaxHistorySize),
+		textInput: ti,
+		multiline: config.StartMultiline,
+		lines:     []string{},
+		width:     config.Width,
+		reg:       reg,
+		sh:        sh,
+		focus:     "input",
+		pub:       pub,
+	}
 }
 
 // Init subscribes to evaluator events.
 func (m *Model) Init() tea.Cmd {
-    return tea.Batch(textinput.Blink, m.sh.Init())
+	// no blinking on text input, because it makes copy paste impossible
+	return tea.Batch(m.sh.Init())
 }
 
 // Update handles TUI events.
 func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
-    switch v := msg.(type) {
-    case tea.WindowSizeMsg:
-        m.width, m.height = v.Width, v.Height
-        m.textInput.Width = max(10, v.Width-10)
-        // give most of the space to timeline shell viewport
-        tlHeight := max(0, v.Height-4)
-        m.sh.SetSize(v.Width, tlHeight)
-        // initial refresh to fit new size
-        m.sh.RefreshView(false)
-        return m, nil
+	log.Trace().Interface("msg", msg).Interface("type", fmt.Sprintf("%T", msg)).Msg("updating repl model")
+	switch v := msg.(type) {
+	case tea.WindowSizeMsg:
+		m.width, m.height = v.Width, v.Height
+		m.textInput.Width = max(10, v.Width-10)
+		// give most of the space to timeline shell viewport
+		tlHeight := max(0, v.Height-4)
+		m.sh.SetSize(v.Width, tlHeight)
+		// initial refresh to fit new size
+		m.sh.RefreshView(false)
+		var cmd tea.Cmd
+		m.textInput, cmd = m.textInput.Update(msg)
+		return m, cmd
 
-    case tea.KeyMsg:
-        switch m.focus {
-        case "input":
-            return m.updateInput(v)
-        case "timeline":
-            return m.updateTimeline(v)
-        }
+	case tea.KeyMsg:
+		switch m.focus {
+		case "input":
+			return m.updateInput(v)
+		case "timeline":
+			return m.updateTimeline(v)
+		}
 
-    case timeline.UIEntityCreated:
-        m.ctrl().OnCreated(v)
-        m.refreshPending = true
-        return m, m.scheduleRefresh()
-    case timeline.UIEntityUpdated:
-        m.ctrl().OnUpdated(v)
-        m.refreshPending = true
-        return m, m.scheduleRefresh()
-    case timeline.UIEntityCompleted:
-        m.ctrl().OnCompleted(v)
-        m.refreshPending = true
-        return m, m.scheduleRefresh()
-    case timeline.UIEntityDeleted:
-        m.ctrl().OnDeleted(v)
-        m.refreshPending = true
-        return m, m.scheduleRefresh()
-    case timelineRefreshMsg:
-        m.refreshScheduled = false
-        if m.refreshPending {
-            m.sh.RefreshView(true)
-            m.refreshPending = false
-        }
-        return m, nil
-    }
+	case timeline.UIEntityCreated:
+		m.ctrl().OnCreated(v)
+		m.refreshPending = true
+		return m, m.scheduleRefresh()
+	case timeline.UIEntityUpdated:
+		m.ctrl().OnUpdated(v)
+		m.refreshPending = true
+		return m, m.scheduleRefresh()
+	case timeline.UIEntityCompleted:
+		m.ctrl().OnCompleted(v)
+		m.refreshPending = true
+		return m, m.scheduleRefresh()
+	case timeline.UIEntityDeleted:
+		m.ctrl().OnDeleted(v)
+		m.refreshPending = true
+		return m, m.scheduleRefresh()
+	case timelineRefreshMsg:
+		m.refreshScheduled = false
+		if m.refreshPending {
+			m.sh.RefreshView(true)
+			m.refreshPending = false
+		}
+		return m, nil
 
-    // default: update input component
-    var cmd tea.Cmd
-    m.textInput, cmd = m.textInput.Update(msg)
-    return m, cmd
+    case cursor.BlinkMsg:
+            return m, nil
+	default:
+		var cmd tea.Cmd
+		m.textInput, cmd = m.textInput.Update(msg)
+		return m, cmd
+	}
+
+	log.Trace().Interface("msg", msg).Msg("updating repl model default case")
+
+	return m, nil
 }
 
 func (m *Model) updateInput(k tea.KeyMsg) (tea.Model, tea.Cmd) {
-    switch k.Type {
-    case tea.KeyCtrlC:
-        return m, tea.Quit
-    }
-    switch k.String() {
-    case "tab":
-        m.focus = "timeline"
-        return m, nil
-    case "enter":
-        input := m.textInput.Value()
-        if strings.TrimSpace(input) == "" {
-            return m, nil
-        }
-        m.textInput.Reset()
-        if m.config.EnableHistory { m.history.Add(input, "", false); m.history.ResetNavigation() }
-        return m, m.submit(input)
-    case "up":
-        if m.config.EnableHistory {
-            if entry := m.history.NavigateUp(); entry != "" { m.textInput.SetValue(entry) }
-        }
-        return m, nil
-    case "down":
-        if m.config.EnableHistory {
-            entry := m.history.NavigateDown(); m.textInput.SetValue(entry)
-        }
-        return m, nil
-    }
-    var cmd tea.Cmd
-    m.textInput, cmd = m.textInput.Update(k)
-    return m, cmd
+	log.Trace().Interface("k", k).Str("key", k.String()).Msg("updating input")
+	switch k.Type {
+	case tea.KeyCtrlC:
+		return m, tea.Quit
+	}
+	switch k.String() {
+	case "tab":
+		m.focus = "timeline"
+		return m, nil
+	case "enter":
+		input := m.textInput.Value()
+		if strings.TrimSpace(input) == "" {
+			return m, nil
+		}
+		m.textInput.Reset()
+		if m.config.EnableHistory {
+			m.history.Add(input, "", false)
+			m.history.ResetNavigation()
+		}
+		return m, m.submit(input)
+	case "up":
+		if m.config.EnableHistory {
+			if entry := m.history.NavigateUp(); entry != "" {
+				m.textInput.SetValue(entry)
+			}
+		}
+		return m, nil
+	case "down":
+		if m.config.EnableHistory {
+			entry := m.history.NavigateDown()
+			m.textInput.SetValue(entry)
+		}
+		return m, nil
+	}
+	var cmd tea.Cmd
+	m.textInput, cmd = m.textInput.Update(k)
+	return m, cmd
 }
 
 func (m *Model) updateTimeline(k tea.KeyMsg) (tea.Model, tea.Cmd) {
-    switch k.String() {
-    case "tab":
-        m.focus = "input"
-        return m, nil
-    case "up":
-        m.sh.SelectPrev(); return m, nil
-    case "down":
-        m.sh.SelectNext(); return m, nil
-    case "enter":
-        if m.sh.IsEntering() { m.sh.ExitSelection() } else { m.sh.EnterSelection() }
-        return m, nil
-    case "c":
-        return m, m.sh.SendToSelected(timeline.EntityCopyCodeMsg{})
-    case "y":
-        return m, m.sh.SendToSelected(timeline.EntityCopyTextMsg{})
-    }
-    // route keys to shell/controller (e.g., Tab cycles inside entity)
-    cmd := m.sh.HandleMsg(k)
-    return m, cmd
+	switch k.String() {
+	case "tab":
+		m.focus = "input"
+		return m, nil
+	case "up":
+		m.sh.SelectPrev()
+		return m, nil
+	case "down":
+		m.sh.SelectNext()
+		return m, nil
+	case "enter":
+		if m.sh.IsEntering() {
+			m.sh.ExitSelection()
+		} else {
+			m.sh.EnterSelection()
+		}
+		return m, nil
+	case "c":
+		return m, m.sh.SendToSelected(timeline.EntityCopyCodeMsg{})
+	case "y":
+		return m, m.sh.SendToSelected(timeline.EntityCopyTextMsg{})
+	}
+	// route keys to shell/controller (e.g., Tab cycles inside entity)
+	cmd := m.sh.HandleMsg(k)
+	return m, cmd
 }
 
 func (m *Model) View() string {
-    var b strings.Builder
-    title := m.config.Title
-    if title == "" { title = fmt.Sprintf("%s REPL", m.evaluator.GetName()) }
-    b.WriteString(m.styles.Title.Render(" "+title+" "))
-    b.WriteString("\n\n")
-    // timeline view (viewport-wrapped)
-    b.WriteString(m.sh.View())
-    b.WriteString("\n")
-    // input
-    b.WriteString(m.textInput.View())
-    b.WriteString("\n")
-    // help
-    help := "TAB: switch focus | Enter: submit | Up/Down: history/selection | c: copy code | y: copy text | Ctrl+C: quit"
-    b.WriteString(m.styles.HelpText.Render(help))
-    b.WriteString("\n")
-    return b.String()
+	var b strings.Builder
+	title := m.config.Title
+	if title == "" {
+		title = fmt.Sprintf("%s REPL", m.evaluator.GetName())
+	}
+	b.WriteString(m.styles.Title.Render(" " + title + " "))
+	b.WriteString("\n\n")
+	// timeline view (viewport-wrapped)
+	b.WriteString(m.sh.View())
+	b.WriteString("\n")
+	// input
+	b.WriteString(m.textInput.View())
+	b.WriteString("\n")
+	// help
+	help := "TAB: switch focus | Enter: submit | Up/Down: history/selection | c: copy code | y: copy text | Ctrl+C: quit"
+	b.WriteString(m.styles.HelpText.Render(help))
+	b.WriteString("\n")
+	return b.String()
 }
 
 // submit runs evaluation and streams events to m.events
 func (m *Model) submit(code string) tea.Cmd {
-    turnID := newTurnID(m.turnSeq)
-    m.turnSeq++
-    // Publish input and stream evaluator events via Watermill
-    go func() {
-        _ = m.publishReplEvent(turnID, Event{Kind: EventInput, Props: map[string]any{"markdown": "```\n" + code + "\n```"}})
-        _ = m.evaluator.EvaluateStream(context.Background(), code, func(e Event) {
-            _ = m.publishReplEvent(turnID, e)
-        })
-    }()
-    return nil
+	return func() tea.Msg {
+		turnID := newTurnID(m.turnSeq)
+		m.turnSeq++
+		// Publish input and stream evaluator events via Watermill
+		_ = m.publishReplEvent(turnID, Event{Kind: EventInput, Props: map[string]any{"markdown": "```\n" + code + "\n```"}})
+		_ = m.evaluator.EvaluateStream(context.Background(), code, func(e Event) {
+			log.Trace().Str("turn_id", turnID).Interface("event", e).Msg("publishing repl event")
+			_ = m.publishReplEvent(turnID, e)
+		})
+		return nil
+	}
 }
 
 func (m *Model) publishReplEvent(turnID string, e Event) error {
-    payload, _ := json.Marshal(struct {
-        TurnID string    `json:"turn_id"`
-        Event  Event     `json:"event"`
-        Time   time.Time `json:"time"`
-    }{TurnID: turnID, Event: e, Time: time.Now()})
-    return m.pub.Publish(eventbus.TopicReplEvents, message.NewMessage(watermill.NewUUID(), payload))
+	payload, _ := json.Marshal(struct {
+		TurnID string    `json:"turn_id"`
+		Event  Event     `json:"event"`
+		Time   time.Time `json:"time"`
+	}{TurnID: turnID, Event: e, Time: time.Now()})
+	log.Trace().Str("turn_id", turnID).Interface("event", e).Msg("publishing repl event")
+	return m.pub.Publish(eventbus.TopicReplEvents, message.NewMessage(watermill.NewUUID(), payload))
 }
 
-
-
-func max(a, b int) int { if a > b { return a }; return b }
+func max(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
+}
 
 func ensureAppendPatch(props map[string]any) map[string]any {
-    if props == nil { return map[string]any{} }
-    if _, ok := props["append"]; ok { return props }
-    if s, ok := props["text"].(string); ok { return map[string]any{"append": s} }
-    return props
+	if props == nil {
+		return map[string]any{}
+	}
+	if _, ok := props["append"]; ok {
+		return props
+	}
+	if s, ok := props["text"].(string); ok {
+		return map[string]any{"append": s}
+	}
+	return props
 }
 
 // internal helpers
 type timelineRefreshMsg struct{}
 
 func (m *Model) scheduleRefresh() tea.Cmd {
-    if m.refreshScheduled { return nil }
-    m.refreshScheduled = true
-    return tea.Tick(50*time.Millisecond, func(time.Time) tea.Msg { return timelineRefreshMsg{} })
+	if m.refreshScheduled {
+		return nil
+	}
+	m.refreshScheduled = true
+	return tea.Tick(50*time.Millisecond, func(time.Time) tea.Msg { return timelineRefreshMsg{} })
 }
 
 func (m *Model) ctrl() *timeline.Controller { return m.sh.Controller() }
 
 func newTurnID(seq int) string {
-    return timeNow().Format("20060102-150405.000000000") + ":" + fmt.Sprintf("%d", seq)
+	return timeNow().Format("20060102-150405.000000000") + ":" + fmt.Sprintf("%d", seq)
 }
 
 func timeNow() time.Time { return time.Now() }

--- a/pkg/repl/repl_test.go
+++ b/pkg/repl/repl_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/go-go-golems/bobatea/pkg/eventbus"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -76,14 +77,15 @@ func TestHistory(t *testing.T) {
 func TestModel(t *testing.T) {
 	evaluator := NewExampleEvaluator()
 	config := DefaultConfig()
-	model := NewModel(evaluator, config)
+	bus, err := eventbus.NewInMemoryBus()
+	assert.NoError(t, err)
+	model := NewModel(evaluator, config, bus.Publisher)
 
 	// Test initialization
 	assert.Equal(t, evaluator, model.evaluator)
 	assert.Equal(t, config, model.config)
-	assert.False(t, model.multilineMode)
-	assert.False(t, model.quitting)
-	assert.False(t, model.evaluating)
+	// multiline should mirror config
+	assert.Equal(t, config.StartMultiline, model.multiline)
 }
 
 func TestConfig(t *testing.T) {
@@ -94,7 +96,8 @@ func TestConfig(t *testing.T) {
 	assert.Equal(t, "Enter code or /command", config.Placeholder)
 	assert.Equal(t, 80, config.Width)
 	assert.False(t, config.StartMultiline)
-	assert.True(t, config.EnableExternalEditor)
+	// Default config for external editor is disabled in timeline-based REPL
+	assert.False(t, config.EnableExternalEditor)
 	assert.True(t, config.EnableHistory)
 	assert.Equal(t, 1000, config.MaxHistorySize)
 }

--- a/pkg/repl/wm_transformer.go
+++ b/pkg/repl/wm_transformer.go
@@ -1,106 +1,143 @@
 package repl
 
 import (
-    "encoding/json"
-    "fmt"
-    "sync"
-    "time"
+	"encoding/json"
+	"fmt"
+	"sync"
+	"time"
 
-    "github.com/ThreeDotsLabs/watermill"
-    "github.com/ThreeDotsLabs/watermill/message"
-    "github.com/go-go-golems/bobatea/pkg/eventbus"
-    "github.com/go-go-golems/bobatea/pkg/timeline"
+	"github.com/ThreeDotsLabs/watermill"
+	"github.com/ThreeDotsLabs/watermill/message"
+	"github.com/go-go-golems/bobatea/pkg/eventbus"
+	"github.com/go-go-golems/bobatea/pkg/timeline"
 )
 
 // replEventMsg is the envelope published by the REPL model.
 type replEventMsg struct {
-    TurnID string    `json:"turn_id"`
-    Event  Event     `json:"event"`
-    Time   time.Time `json:"time"`
+	TurnID string    `json:"turn_id"`
+	Event  Event     `json:"event"`
+	Time   time.Time `json:"time"`
 }
 
 // uiEnvelope wraps timeline messages for the ui.entities topic.
 type uiEnvelope struct {
-    Type    string          `json:"type"`
-    Payload json.RawMessage `json:"payload"`
+	Type    string          `json:"type"`
+	Payload json.RawMessage `json:"payload"`
 }
 
 // RegisterReplToTimelineTransformer subscribes to repl.events and publishes timeline lifecycle messages to ui.entities.
 func RegisterReplToTimelineTransformer(bus *eventbus.Bus) {
-    // minimal state to avoid duplicate stdout/stderr create per turn
-    var mu sync.Mutex
-    type turnState struct{ stdout, stderr bool; seq int }
-    byTurn := map[string]*turnState{}
+	// minimal state to avoid duplicate stdout/stderr create per turn
+	var mu sync.Mutex
+	type turnState struct {
+		stdout, stderr bool
+		seq            int
+	}
+	byTurn := map[string]*turnState{}
 
-    publish := func(msgType string, v any) error {
-        b, _ := json.Marshal(v)
-        env, _ := json.Marshal(uiEnvelope{Type: msgType, Payload: b})
-        return bus.Publisher.Publish(eventbus.TopicUIEntities, message.NewMessage(watermill.NewUUID(), env))
-    }
+	publish := func(msgType string, v any) error {
+		b, _ := json.Marshal(v)
+		env, _ := json.Marshal(uiEnvelope{Type: msgType, Payload: b})
+		return bus.Publisher.Publish(eventbus.TopicUIEntities, message.NewMessage(watermill.NewUUID(), env))
+	}
 
-    bus.AddHandler("repl-to-ui", eventbus.TopicReplEvents, func(msg *message.Message) error {
-        defer msg.Ack()
-        var in replEventMsg
-        if err := json.Unmarshal(msg.Payload, &in); err != nil {
-            return err
-        }
-        turnID := in.TurnID
-        mu.Lock()
-        st := byTurn[turnID]
-        if st == nil {
-            st = &turnState{}
-            byTurn[turnID] = st
-        }
-        mu.Unlock()
+	bus.AddHandler("repl-to-ui", eventbus.TopicReplEvents, func(msg *message.Message) error {
+		defer msg.Ack()
+		var in replEventMsg
+		if err := json.Unmarshal(msg.Payload, &in); err != nil {
+			return err
+		}
+		turnID := in.TurnID
+		mu.Lock()
+		st := byTurn[turnID]
+		if st == nil {
+			st = &turnState{}
+			byTurn[turnID] = st
+		}
+		mu.Unlock()
 
-        switch in.Event.Kind {
-        case EventInput:
-            e := timeline.UIEntityCreated{ID: timeline.EntityID{TurnID: turnID, LocalID: "input", Kind: "markdown"}, Renderer: timeline.RendererDescriptor{Kind: "markdown"}, Props: in.Event.Props, StartedAt: time.Now()}
-            return publish("timeline.created", e)
-        case EventStdout:
-            mu.Lock()
-            needCreate := !st.stdout
-            if needCreate {
-                st.stdout = true
-            }
-            mu.Unlock()
-            if needCreate {
-                c := timeline.UIEntityCreated{ID: timeline.EntityID{TurnID: turnID, LocalID: "stdout", Kind: "text"}, Renderer: timeline.RendererDescriptor{Kind: "text"}, Props: map[string]any{"text": "", "streaming": true}, StartedAt: time.Now()}
-                if err := publish("timeline.created", c); err != nil { return err }
-            }
-            u := timeline.UIEntityUpdated{ID: timeline.EntityID{TurnID: turnID, LocalID: "stdout", Kind: "text"}, Patch: ensureAppendPatch(in.Event.Props), Version: time.Now().UnixNano(), UpdatedAt: time.Now()}
-            return publish("timeline.updated", u)
-        case EventStderr:
-            mu.Lock()
-            needCreate := !st.stderr
-            if needCreate {
-                st.stderr = true
-            }
-            mu.Unlock()
-            if needCreate {
-                c := timeline.UIEntityCreated{ID: timeline.EntityID{TurnID: turnID, LocalID: "stderr", Kind: "text"}, Renderer: timeline.RendererDescriptor{Kind: "text"}, Props: map[string]any{"text": "", "streaming": true, "is_error": true}, StartedAt: time.Now()}
-                if err := publish("timeline.created", c); err != nil { return err }
-            }
-            p := ensureAppendPatch(in.Event.Props)
-            p["is_error"] = true
-            u := timeline.UIEntityUpdated{ID: timeline.EntityID{TurnID: turnID, LocalID: "stderr", Kind: "text"}, Patch: p, Version: time.Now().UnixNano(), UpdatedAt: time.Now()}
-            return publish("timeline.updated", u)
-        case EventResultMarkdown:
-            mu.Lock(); st.seq++; local := fmt.Sprintf("result-%d", st.seq); mu.Unlock()
-            c := timeline.UIEntityCreated{ID: timeline.EntityID{TurnID: turnID, LocalID: local, Kind: "markdown"}, Renderer: timeline.RendererDescriptor{Kind: "markdown"}, Props: in.Event.Props, StartedAt: time.Now()}
-            if err := publish("timeline.created", c); err != nil { return err }
-            return publish("timeline.completed", timeline.UIEntityCompleted{ID: c.ID, Result: nil})
-        case EventInspector:
-            mu.Lock(); st.seq++; local := fmt.Sprintf("inspect-%d", st.seq); mu.Unlock()
-            c := timeline.UIEntityCreated{ID: timeline.EntityID{TurnID: turnID, LocalID: local, Kind: "structured_data"}, Renderer: timeline.RendererDescriptor{Kind: "structured_data"}, Props: in.Event.Props, StartedAt: time.Now()}
-            if err := publish("timeline.created", c); err != nil { return err }
-            return publish("timeline.completed", timeline.UIEntityCompleted{ID: c.ID, Result: nil})
-        default:
-            mu.Lock(); st.seq++; local := fmt.Sprintf("event-%d", st.seq); mu.Unlock()
-            c := timeline.UIEntityCreated{ID: timeline.EntityID{TurnID: turnID, LocalID: local, Kind: "text"}, Renderer: timeline.RendererDescriptor{Kind: "text"}, Props: in.Event.Props, StartedAt: time.Now()}
-            if err := publish("timeline.created", c); err != nil { return err }
-            return publish("timeline.completed", timeline.UIEntityCompleted{ID: c.ID, Result: nil})
-        }
-    })
+		//nolint:exhaustive
+		switch in.Event.Kind {
+		case EventInput:
+			e := timeline.UIEntityCreated{ID: timeline.EntityID{TurnID: turnID, LocalID: "input", Kind: "markdown"}, Renderer: timeline.RendererDescriptor{Kind: "markdown"}, Props: in.Event.Props, StartedAt: time.Now()}
+			return publish("timeline.created", e)
+		case EventStdout:
+			mu.Lock()
+			needCreate := !st.stdout
+			if needCreate {
+				st.stdout = true
+			}
+			mu.Unlock()
+			if needCreate {
+				c := timeline.UIEntityCreated{ID: timeline.EntityID{TurnID: turnID, LocalID: "stdout", Kind: "text"}, Renderer: timeline.RendererDescriptor{Kind: "text"}, Props: map[string]any{"text": "", "streaming": true}, StartedAt: time.Now()}
+				if err := publish("timeline.created", c); err != nil {
+					return err
+				}
+			}
+			u := timeline.UIEntityUpdated{ID: timeline.EntityID{TurnID: turnID, LocalID: "stdout", Kind: "text"}, Patch: ensureAppendPatch(in.Event.Props), Version: time.Now().UnixNano(), UpdatedAt: time.Now()}
+			return publish("timeline.updated", u)
+		case EventStderr:
+			mu.Lock()
+			needCreate := !st.stderr
+			if needCreate {
+				st.stderr = true
+			}
+			mu.Unlock()
+			if needCreate {
+				c := timeline.UIEntityCreated{ID: timeline.EntityID{TurnID: turnID, LocalID: "stderr", Kind: "text"}, Renderer: timeline.RendererDescriptor{Kind: "text"}, Props: map[string]any{"text": "", "streaming": true, "is_error": true}, StartedAt: time.Now()}
+				if err := publish("timeline.created", c); err != nil {
+					return err
+				}
+			}
+			p := ensureAppendPatch(in.Event.Props)
+			p["is_error"] = true
+			u := timeline.UIEntityUpdated{ID: timeline.EntityID{TurnID: turnID, LocalID: "stderr", Kind: "text"}, Patch: p, Version: time.Now().UnixNano(), UpdatedAt: time.Now()}
+			return publish("timeline.updated", u)
+		case EventResultMarkdown:
+			mu.Lock()
+			st.seq++
+			local := fmt.Sprintf("result-%d", st.seq)
+			mu.Unlock()
+			c := timeline.UIEntityCreated{ID: timeline.EntityID{TurnID: turnID, LocalID: local, Kind: "markdown"}, Renderer: timeline.RendererDescriptor{Kind: "markdown"}, Props: in.Event.Props, StartedAt: time.Now()}
+			if err := publish("timeline.created", c); err != nil {
+				return err
+			}
+			return publish("timeline.completed", timeline.UIEntityCompleted{ID: c.ID, Result: nil})
+		case EventLog:
+			mu.Lock()
+			st.seq++
+			local := fmt.Sprintf("log-%d", st.seq)
+			mu.Unlock()
+			c := timeline.UIEntityCreated{ID: timeline.EntityID{TurnID: turnID, LocalID: local, Kind: "log_event"}, Renderer: timeline.RendererDescriptor{Kind: "log_event"}, Props: in.Event.Props, StartedAt: time.Now()}
+			if err := publish("timeline.created", c); err != nil {
+				return err
+			}
+			return publish("timeline.completed", timeline.UIEntityCompleted{ID: c.ID, Result: nil})
+		case EventStructuredLog:
+			mu.Lock(); st.seq++; local := fmt.Sprintf("slog-%d", st.seq); mu.Unlock()
+			c := timeline.UIEntityCreated{ID: timeline.EntityID{TurnID: turnID, LocalID: local, Kind: "structured_log_event"}, Renderer: timeline.RendererDescriptor{Kind: "structured_log_event"}, Props: in.Event.Props, StartedAt: time.Now()}
+			if err := publish("timeline.created", c); err != nil { return err }
+			return publish("timeline.completed", timeline.UIEntityCompleted{ID: c.ID, Result: nil})
+		case EventInspector:
+			mu.Lock()
+			st.seq++
+			local := fmt.Sprintf("inspect-%d", st.seq)
+			mu.Unlock()
+			c := timeline.UIEntityCreated{ID: timeline.EntityID{TurnID: turnID, LocalID: local, Kind: "structured_data"}, Renderer: timeline.RendererDescriptor{Kind: "structured_data"}, Props: in.Event.Props, StartedAt: time.Now()}
+			if err := publish("timeline.created", c); err != nil {
+				return err
+			}
+			return publish("timeline.completed", timeline.UIEntityCompleted{ID: c.ID, Result: nil})
+		default:
+			mu.Lock()
+			st.seq++
+			local := fmt.Sprintf("event-%d", st.seq)
+			mu.Unlock()
+			c := timeline.UIEntityCreated{ID: timeline.EntityID{TurnID: turnID, LocalID: local, Kind: "text"}, Renderer: timeline.RendererDescriptor{Kind: "text"}, Props: in.Event.Props, StartedAt: time.Now()}
+			if err := publish("timeline.created", c); err != nil {
+				return err
+			}
+			return publish("timeline.completed", timeline.UIEntityCompleted{ID: c.ID, Result: nil})
+		}
+	})
 }
-

--- a/pkg/repl/wm_transformer.go
+++ b/pkg/repl/wm_transformer.go
@@ -114,9 +114,14 @@ func RegisterReplToTimelineTransformer(bus *eventbus.Bus) {
 			}
 			return publish("timeline.completed", timeline.UIEntityCompleted{ID: c.ID, Result: nil})
 		case EventStructuredLog:
-			mu.Lock(); st.seq++; local := fmt.Sprintf("slog-%d", st.seq); mu.Unlock()
+			mu.Lock()
+			st.seq++
+			local := fmt.Sprintf("slog-%d", st.seq)
+			mu.Unlock()
 			c := timeline.UIEntityCreated{ID: timeline.EntityID{TurnID: turnID, LocalID: local, Kind: "structured_log_event"}, Renderer: timeline.RendererDescriptor{Kind: "structured_log_event"}, Props: in.Event.Props, StartedAt: time.Now()}
-			if err := publish("timeline.created", c); err != nil { return err }
+			if err := publish("timeline.created", c); err != nil {
+				return err
+			}
 			return publish("timeline.completed", timeline.UIEntityCompleted{ID: c.ID, Result: nil})
 		case EventInspector:
 			mu.Lock()

--- a/pkg/repl/wm_transformer.go
+++ b/pkg/repl/wm_transformer.go
@@ -1,0 +1,106 @@
+package repl
+
+import (
+    "encoding/json"
+    "fmt"
+    "sync"
+    "time"
+
+    "github.com/ThreeDotsLabs/watermill"
+    "github.com/ThreeDotsLabs/watermill/message"
+    "github.com/go-go-golems/bobatea/pkg/eventbus"
+    "github.com/go-go-golems/bobatea/pkg/timeline"
+)
+
+// replEventMsg is the envelope published by the REPL model.
+type replEventMsg struct {
+    TurnID string    `json:"turn_id"`
+    Event  Event     `json:"event"`
+    Time   time.Time `json:"time"`
+}
+
+// uiEnvelope wraps timeline messages for the ui.entities topic.
+type uiEnvelope struct {
+    Type    string          `json:"type"`
+    Payload json.RawMessage `json:"payload"`
+}
+
+// RegisterReplToTimelineTransformer subscribes to repl.events and publishes timeline lifecycle messages to ui.entities.
+func RegisterReplToTimelineTransformer(bus *eventbus.Bus) {
+    // minimal state to avoid duplicate stdout/stderr create per turn
+    var mu sync.Mutex
+    type turnState struct{ stdout, stderr bool; seq int }
+    byTurn := map[string]*turnState{}
+
+    publish := func(msgType string, v any) error {
+        b, _ := json.Marshal(v)
+        env, _ := json.Marshal(uiEnvelope{Type: msgType, Payload: b})
+        return bus.Publisher.Publish(eventbus.TopicUIEntities, message.NewMessage(watermill.NewUUID(), env))
+    }
+
+    bus.AddHandler("repl-to-ui", eventbus.TopicReplEvents, func(msg *message.Message) error {
+        defer msg.Ack()
+        var in replEventMsg
+        if err := json.Unmarshal(msg.Payload, &in); err != nil {
+            return err
+        }
+        turnID := in.TurnID
+        mu.Lock()
+        st := byTurn[turnID]
+        if st == nil {
+            st = &turnState{}
+            byTurn[turnID] = st
+        }
+        mu.Unlock()
+
+        switch in.Event.Kind {
+        case EventInput:
+            e := timeline.UIEntityCreated{ID: timeline.EntityID{TurnID: turnID, LocalID: "input", Kind: "markdown"}, Renderer: timeline.RendererDescriptor{Kind: "markdown"}, Props: in.Event.Props, StartedAt: time.Now()}
+            return publish("timeline.created", e)
+        case EventStdout:
+            mu.Lock()
+            needCreate := !st.stdout
+            if needCreate {
+                st.stdout = true
+            }
+            mu.Unlock()
+            if needCreate {
+                c := timeline.UIEntityCreated{ID: timeline.EntityID{TurnID: turnID, LocalID: "stdout", Kind: "text"}, Renderer: timeline.RendererDescriptor{Kind: "text"}, Props: map[string]any{"text": "", "streaming": true}, StartedAt: time.Now()}
+                if err := publish("timeline.created", c); err != nil { return err }
+            }
+            u := timeline.UIEntityUpdated{ID: timeline.EntityID{TurnID: turnID, LocalID: "stdout", Kind: "text"}, Patch: ensureAppendPatch(in.Event.Props), Version: time.Now().UnixNano(), UpdatedAt: time.Now()}
+            return publish("timeline.updated", u)
+        case EventStderr:
+            mu.Lock()
+            needCreate := !st.stderr
+            if needCreate {
+                st.stderr = true
+            }
+            mu.Unlock()
+            if needCreate {
+                c := timeline.UIEntityCreated{ID: timeline.EntityID{TurnID: turnID, LocalID: "stderr", Kind: "text"}, Renderer: timeline.RendererDescriptor{Kind: "text"}, Props: map[string]any{"text": "", "streaming": true, "is_error": true}, StartedAt: time.Now()}
+                if err := publish("timeline.created", c); err != nil { return err }
+            }
+            p := ensureAppendPatch(in.Event.Props)
+            p["is_error"] = true
+            u := timeline.UIEntityUpdated{ID: timeline.EntityID{TurnID: turnID, LocalID: "stderr", Kind: "text"}, Patch: p, Version: time.Now().UnixNano(), UpdatedAt: time.Now()}
+            return publish("timeline.updated", u)
+        case EventResultMarkdown:
+            mu.Lock(); st.seq++; local := fmt.Sprintf("result-%d", st.seq); mu.Unlock()
+            c := timeline.UIEntityCreated{ID: timeline.EntityID{TurnID: turnID, LocalID: local, Kind: "markdown"}, Renderer: timeline.RendererDescriptor{Kind: "markdown"}, Props: in.Event.Props, StartedAt: time.Now()}
+            if err := publish("timeline.created", c); err != nil { return err }
+            return publish("timeline.completed", timeline.UIEntityCompleted{ID: c.ID, Result: nil})
+        case EventInspector:
+            mu.Lock(); st.seq++; local := fmt.Sprintf("inspect-%d", st.seq); mu.Unlock()
+            c := timeline.UIEntityCreated{ID: timeline.EntityID{TurnID: turnID, LocalID: local, Kind: "structured_data"}, Renderer: timeline.RendererDescriptor{Kind: "structured_data"}, Props: in.Event.Props, StartedAt: time.Now()}
+            if err := publish("timeline.created", c); err != nil { return err }
+            return publish("timeline.completed", timeline.UIEntityCompleted{ID: c.ID, Result: nil})
+        default:
+            mu.Lock(); st.seq++; local := fmt.Sprintf("event-%d", st.seq); mu.Unlock()
+            c := timeline.UIEntityCreated{ID: timeline.EntityID{TurnID: turnID, LocalID: local, Kind: "text"}, Renderer: timeline.RendererDescriptor{Kind: "text"}, Props: in.Event.Props, StartedAt: time.Now()}
+            if err := publish("timeline.created", c); err != nil { return err }
+            return publish("timeline.completed", timeline.UIEntityCompleted{ID: c.ID, Result: nil})
+        }
+    })
+}
+

--- a/pkg/timeline/controller.go
+++ b/pkg/timeline/controller.go
@@ -1,12 +1,12 @@
 package timeline
 
 import (
-    "encoding/json"
-    "fmt"
-    tea "github.com/charmbracelet/bubbletea"
-    "github.com/rs/zerolog/log"
-    "strings"
-    "time"
+	"encoding/json"
+	"fmt"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/rs/zerolog/log"
+	"strings"
+	"time"
 )
 
 type Controller struct {
@@ -171,27 +171,27 @@ func (c *Controller) View() string {
 		log.Trace().Str("component", "timeline_controller").Str("phase", "view").Str("entity_id", rec.ID.LocalID).Str("entity_kind", rec.ID.Kind).Msg("rendering entity")
 		// Interactive models are now the only rendering path
 		sel := c.selectionVisible && c.selected >= 0 && keyID(id) == keyID(c.store.order[c.selected])
-        if rec.model != nil {
-            rec.model.Update(EntityPropsUpdatedMsg{ID: rec.ID, Patch: map[string]any{"selected": sel}})
-            if sel {
-                rec.model.Update(EntitySelectedMsg{ID: rec.ID})
-            } else {
-                rec.model.Update(EntityUnselectedMsg{ID: rec.ID})
-            }
-            if sel && c.entering {
-                rec.model.Update(EntityFocusMsg{ID: rec.ID})
-            } else {
-                rec.model.Update(EntityBlurMsg{ID: rec.ID})
-            }
-            start := time.Now()
-            log.Trace().Str("component", "timeline_controller").Str("phase", "view").Str("entity_id", rec.ID.LocalID).Str("entity_kind", rec.ID.Kind).Msg("calling model.View")
-            s := rec.model.View()
-            dur := time.Since(start)
-            log.Trace().Str("component", "timeline_controller").Str("phase", "view").Str("entity_id", rec.ID.LocalID).Str("entity_kind", rec.ID.Kind).Dur("dur", dur).Int("len", len(s)).Msg("model.View duration")
-            b.WriteString(s)
-            b.WriteByte('\n')
-            continue
-        }
+		if rec.model != nil {
+			rec.model.Update(EntityPropsUpdatedMsg{ID: rec.ID, Patch: map[string]any{"selected": sel}})
+			if sel {
+				rec.model.Update(EntitySelectedMsg{ID: rec.ID})
+			} else {
+				rec.model.Update(EntityUnselectedMsg{ID: rec.ID})
+			}
+			if sel && c.entering {
+				rec.model.Update(EntityFocusMsg{ID: rec.ID})
+			} else {
+				rec.model.Update(EntityBlurMsg{ID: rec.ID})
+			}
+			start := time.Now()
+			log.Trace().Str("component", "timeline_controller").Str("phase", "view").Str("entity_id", rec.ID.LocalID).Str("entity_kind", rec.ID.Kind).Msg("calling model.View")
+			s := rec.model.View()
+			dur := time.Since(start)
+			log.Trace().Str("component", "timeline_controller").Str("phase", "view").Str("entity_id", rec.ID.LocalID).Str("entity_kind", rec.ID.Kind).Dur("dur", dur).Int("len", len(s)).Msg("model.View duration")
+			b.WriteString(s)
+			b.WriteByte('\n')
+			continue
+		}
 		// If no model, render a minimal plain line
 		s := "[entity] " + rec.ID.Kind
 		b.WriteString(s)

--- a/pkg/timeline/renderers/log_event_model.go
+++ b/pkg/timeline/renderers/log_event_model.go
@@ -1,13 +1,13 @@
 package renderers
 
 import (
-    "strings"
+	"strings"
 
-    tea "github.com/charmbracelet/bubbletea"
-    "github.com/charmbracelet/lipgloss"
-    "github.com/go-go-golems/bobatea/pkg/timeline"
-    "github.com/rs/zerolog/log"
-    "gopkg.in/yaml.v3"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+	"github.com/go-go-golems/bobatea/pkg/timeline"
+	"github.com/rs/zerolog/log"
+	"gopkg.in/yaml.v3"
 )
 
 // LogEventModel renders a compact, borderless gray log entry with YAML-formatted metadata/fields
@@ -53,38 +53,40 @@ func (m *LogEventModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 }
 
 func (m *LogEventModel) View() string {
-    // Container (no foreground to allow inner colored spans)
-    base := lipgloss.NewStyle().Padding(0, 1)
+	// Container (no foreground to allow inner colored spans)
+	base := lipgloss.NewStyle().Padding(0, 1)
 
-    level := strings.ToUpper(strings.TrimSpace(m.level))
-    msg := strings.TrimSpace(m.message)
+	level := strings.ToUpper(strings.TrimSpace(m.level))
+	msg := strings.TrimSpace(m.message)
 
-    // Level color
-    var lvlColor lipgloss.Color
-    switch strings.ToLower(level) {
-    case "error", "err":
-        lvlColor = lipgloss.Color("196")
-    case "warn", "warning":
-        lvlColor = lipgloss.Color("214")
-    case "debug":
-        lvlColor = lipgloss.Color("243")
-    case "info":
-        lvlColor = lipgloss.Color("39")
-    default:
-        lvlColor = lipgloss.Color("245")
-    }
+	// Level color
+	var lvlColor lipgloss.Color
+	switch strings.ToLower(level) {
+	case "error", "err":
+		lvlColor = lipgloss.Color("196")
+	case "warn", "warning":
+		lvlColor = lipgloss.Color("214")
+	case "debug":
+		lvlColor = lipgloss.Color("243")
+	case "info":
+		lvlColor = lipgloss.Color("39")
+	default:
+		lvlColor = lipgloss.Color("245")
+	}
 
-    lvl := lipgloss.NewStyle().Foreground(lvlColor).Bold(true).Render("[" + level + "]")
-    msgColor := lipgloss.Color("245")
-    if m.selected { msgColor = lipgloss.Color("252") }
-    msgStyled := lipgloss.NewStyle().Foreground(msgColor).Render(msg)
+	lvl := lipgloss.NewStyle().Foreground(lvlColor).Bold(true).Render("[" + level + "]")
+	msgColor := lipgloss.Color("245")
+	if m.selected {
+		msgColor = lipgloss.Color("252")
+	}
+	msgStyled := lipgloss.NewStyle().Foreground(msgColor).Render(msg)
 
-    body := strings.TrimSpace(lvl + " " + msgStyled)
-    if m.showMeta && strings.TrimSpace(m.yamlStr) != "" {
-        meta := lipgloss.NewStyle().Foreground(lipgloss.Color("244")).Render(m.yamlStr)
-        body += "\n\n" + meta
-    }
-    return base.Width(m.width - base.GetHorizontalPadding()).Render(body)
+	body := strings.TrimSpace(lvl + " " + msgStyled)
+	if m.showMeta && strings.TrimSpace(m.yamlStr) != "" {
+		meta := lipgloss.NewStyle().Foreground(lipgloss.Color("244")).Render(m.yamlStr)
+		body += "\n\n" + meta
+	}
+	return base.Width(m.width - base.GetHorizontalPadding()).Render(body)
 }
 
 func (m *LogEventModel) OnProps(patch map[string]any) {

--- a/pkg/timeline/renderers/log_event_model.go
+++ b/pkg/timeline/renderers/log_event_model.go
@@ -1,14 +1,13 @@
 package renderers
 
 import (
-	"fmt"
-	"strings"
+    "strings"
 
-	tea "github.com/charmbracelet/bubbletea"
-	"github.com/charmbracelet/lipgloss"
-	"github.com/go-go-golems/bobatea/pkg/timeline"
-	"github.com/rs/zerolog/log"
-	"gopkg.in/yaml.v3"
+    tea "github.com/charmbracelet/bubbletea"
+    "github.com/charmbracelet/lipgloss"
+    "github.com/go-go-golems/bobatea/pkg/timeline"
+    "github.com/rs/zerolog/log"
+    "gopkg.in/yaml.v3"
 )
 
 // LogEventModel renders a compact, borderless gray log entry with YAML-formatted metadata/fields
@@ -54,21 +53,38 @@ func (m *LogEventModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 }
 
 func (m *LogEventModel) View() string {
-	// Borderless, unobtrusive gray style
-	base := lipgloss.NewStyle().Padding(0, 1)
-	// Darker gray foreground (adaptive-ish by using numbers)
-	gray := lipgloss.Color("245")
-	if m.selected {
-		gray = lipgloss.Color("252")
-	}
-	base = base.Foreground(gray)
+    // Container (no foreground to allow inner colored spans)
+    base := lipgloss.NewStyle().Padding(0, 1)
 
-	header := strings.TrimSpace(fmt.Sprintf("[%s] %s", strings.ToUpper(strings.TrimSpace(m.level)), strings.TrimSpace(m.message)))
-	body := header
-	if m.showMeta && strings.TrimSpace(m.yamlStr) != "" {
-		body += "\n\n" + m.yamlStr
-	}
-	return base.Width(m.width - base.GetHorizontalPadding()).Render(body)
+    level := strings.ToUpper(strings.TrimSpace(m.level))
+    msg := strings.TrimSpace(m.message)
+
+    // Level color
+    var lvlColor lipgloss.Color
+    switch strings.ToLower(level) {
+    case "error", "err":
+        lvlColor = lipgloss.Color("196")
+    case "warn", "warning":
+        lvlColor = lipgloss.Color("214")
+    case "debug":
+        lvlColor = lipgloss.Color("243")
+    case "info":
+        lvlColor = lipgloss.Color("39")
+    default:
+        lvlColor = lipgloss.Color("245")
+    }
+
+    lvl := lipgloss.NewStyle().Foreground(lvlColor).Bold(true).Render("[" + level + "]")
+    msgColor := lipgloss.Color("245")
+    if m.selected { msgColor = lipgloss.Color("252") }
+    msgStyled := lipgloss.NewStyle().Foreground(msgColor).Render(msg)
+
+    body := strings.TrimSpace(lvl + " " + msgStyled)
+    if m.showMeta && strings.TrimSpace(m.yamlStr) != "" {
+        meta := lipgloss.NewStyle().Foreground(lipgloss.Color("244")).Render(m.yamlStr)
+        body += "\n\n" + meta
+    }
+    return base.Width(m.width - base.GetHorizontalPadding()).Render(body)
 }
 
 func (m *LogEventModel) OnProps(patch map[string]any) {

--- a/pkg/timeline/renderers/markdown_model.go
+++ b/pkg/timeline/renderers/markdown_model.go
@@ -109,6 +109,10 @@ func (m *MarkdownModel) View() string {
         m.cachedMD = m.md
     }
 
+    // Add selection indicator
+    if m.selected {
+        body = "▶ " + body
+    }
     // Box it
     return sty.Width(m.width - sty.GetHorizontalPadding()).Render(body)
 }

--- a/pkg/timeline/renderers/markdown_model.go
+++ b/pkg/timeline/renderers/markdown_model.go
@@ -1,0 +1,118 @@
+package renderers
+
+import (
+    "os"
+    "strings"
+
+    tea "github.com/charmbracelet/bubbletea"
+    "github.com/charmbracelet/glamour"
+    "github.com/go-go-golems/bobatea/pkg/timeline"
+    chatstyle "github.com/go-go-golems/bobatea/pkg/timeline/chatstyle"
+    "github.com/muesli/termenv"
+    "golang.org/x/term"
+)
+
+// MarkdownModel renders markdown with glamour.
+type MarkdownModel struct {
+    width     int
+    selected  bool
+    streaming bool
+    md        string
+    renderer  *glamour.TermRenderer
+}
+
+func (m *MarkdownModel) Init() tea.Cmd { return nil }
+
+func (m *MarkdownModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+    switch v := msg.(type) {
+    case timeline.EntitySelectedMsg:
+        m.selected = true
+    case timeline.EntityUnselectedMsg:
+        m.selected = false
+    case timeline.EntitySetSizeMsg:
+        m.width = v.Width
+    case timeline.EntityPropsUpdatedMsg:
+        if v.Patch != nil {
+            m.onProps(v.Patch)
+        }
+    case timeline.EntityCopyTextMsg:
+        // Copy raw markdown text
+        return m, func() tea.Msg { return timeline.CopyTextRequestedMsg{Text: m.md} }
+    case timeline.EntityCopyCodeMsg:
+        blocks := extractAllCodeBlocks(m.md)
+        if len(blocks) > 0 {
+            joined := strings.Join(blocks, "\n\n")
+            return m, func() tea.Msg { return timeline.CopyCodeRequestedMsg{Code: joined} }
+        }
+        return m, func() tea.Msg { return timeline.CopyTextRequestedMsg{Text: m.md} }
+    }
+    return m, nil
+}
+
+func (m *MarkdownModel) onProps(patch map[string]any) {
+    if v, ok := patch["selected"].(bool); ok {
+        m.selected = v
+    }
+    if v, ok := patch["streaming"].(bool); ok {
+        m.streaming = v
+    }
+    // accept either "markdown" or "text"
+    if v, ok := patch["markdown"].(string); ok {
+        m.md = v
+    } else if v, ok := patch["text"].(string); ok {
+        m.md = v
+    }
+}
+
+func (m *MarkdownModel) View() string {
+    st := chatstyle.DefaultStyles()
+    sty := st.UnselectedMessage
+    if m.selected {
+        sty = st.SelectedMessage
+    }
+
+    if m.renderer == nil {
+        m.renderer = newGlamourRenderer()
+    }
+    var body string
+    if m.renderer != nil {
+        if out, err := m.renderer.Render(strings.TrimSpace(m.md) + "\n"); err == nil {
+            body = strings.TrimSpace(out)
+        }
+    }
+    if body == "" {
+        body = m.md
+    }
+
+    // Box it
+    return sty.Width(m.width - sty.GetHorizontalPadding()).Render(body)
+}
+
+type MarkdownFactory struct{}
+
+func (MarkdownFactory) Key() string  { return "renderer.markdown.v1" }
+func (MarkdownFactory) Kind() string { return "markdown" }
+func (MarkdownFactory) NewEntityModel(initialProps map[string]any) timeline.EntityModel {
+    m := &MarkdownModel{}
+    m.onProps(initialProps)
+    return m
+}
+
+func newGlamourRenderer() *glamour.TermRenderer {
+    var style string
+    if !term.IsTerminal(int(os.Stdout.Fd())) {
+        style = "notty"
+    } else if termenv.HasDarkBackground() {
+        style = "dark"
+    } else {
+        style = "light"
+    }
+    r, err := glamour.NewTermRenderer(
+        glamour.WithStandardStyle(style),
+        glamour.WithWordWrap(80),
+    )
+    if err != nil {
+        return nil
+    }
+    return r
+}

--- a/pkg/timeline/renderers/markdown_model.go
+++ b/pkg/timeline/renderers/markdown_model.go
@@ -18,99 +18,103 @@ import (
 
 // MarkdownModel renders markdown with glamour.
 type MarkdownModel struct {
-    width     int
-    selected  bool
-    streaming bool
-    md        string
-    renderer  *glamour.TermRenderer
-    // cache rendered output by width and content
-    cachedRendered string
-    cachedWidth    int
-    cachedMD       string
+	width     int
+	selected  bool
+	streaming bool
+	md        string
+	renderer  *glamour.TermRenderer
+	// cache rendered output by width and content
+	cachedRendered string
+	cachedWidth    int
+	cachedMD       string
 }
 
 func (m *MarkdownModel) Init() tea.Cmd { return nil }
 
 func (m *MarkdownModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
-    switch v := msg.(type) {
-    case timeline.EntitySelectedMsg:
-        m.selected = true
-    case timeline.EntityUnselectedMsg:
-        m.selected = false
-    case timeline.EntitySetSizeMsg:
-        m.width = v.Width
-    case timeline.EntityPropsUpdatedMsg:
-        log.Trace().Interface("msg", msg).Msg("updating markdown model")
-        if v.Patch != nil {
-            m.onProps(v.Patch)
-        }
-    case timeline.EntityCopyTextMsg:
-        // Copy raw markdown text
-        log.Trace().Interface("msg", msg).Msg("copying markdown text")
-        return m, func() tea.Msg { return timeline.CopyTextRequestedMsg{Text: m.md} }
-    case timeline.EntityCopyCodeMsg:
-        log.Trace().Interface("msg", msg).Msg("copying code")
-        blocks := mdExtractAllCodeBlocks(m.md)
-        if len(blocks) > 0 {
-            joined := strings.Join(blocks, "\n\n")
-            return m, func() tea.Msg { return timeline.CopyCodeRequestedMsg{Code: joined} }
-        }
-        return m, func() tea.Msg { return timeline.CopyTextRequestedMsg{Text: m.md} }
-    }
-    log.Trace().Interface("msg", msg).Msg("updating markdown model default case")
-    return m, nil
+	switch v := msg.(type) {
+	case timeline.EntitySelectedMsg:
+		m.selected = true
+	case timeline.EntityUnselectedMsg:
+		m.selected = false
+	case timeline.EntitySetSizeMsg:
+		m.width = v.Width
+	case timeline.EntityPropsUpdatedMsg:
+		log.Trace().Interface("msg", msg).Msg("updating markdown model")
+		if v.Patch != nil {
+			m.onProps(v.Patch)
+		}
+	case timeline.EntityCopyTextMsg:
+		// Copy raw markdown text
+		log.Trace().Interface("msg", msg).Msg("copying markdown text")
+		return m, func() tea.Msg { return timeline.CopyTextRequestedMsg{Text: m.md} }
+	case timeline.EntityCopyCodeMsg:
+		log.Trace().Interface("msg", msg).Msg("copying code")
+		blocks := mdExtractAllCodeBlocks(m.md)
+		if len(blocks) > 0 {
+			joined := strings.Join(blocks, "\n\n")
+			return m, func() tea.Msg { return timeline.CopyCodeRequestedMsg{Code: joined} }
+		}
+		return m, func() tea.Msg { return timeline.CopyTextRequestedMsg{Text: m.md} }
+	}
+	log.Trace().Interface("msg", msg).Msg("updating markdown model default case")
+	return m, nil
 }
 
 func (m *MarkdownModel) onProps(patch map[string]any) {
-    if v, ok := patch["selected"].(bool); ok {
-        m.selected = v
-    }
-    if v, ok := patch["streaming"].(bool); ok {
-        m.streaming = v
-    }
-    // accept either "markdown" or "text"
-    if v, ok := patch["markdown"].(string); ok {
-        m.md = v
-    } else if v, ok := patch["text"].(string); ok {
-        m.md = v
-    }
+	if v, ok := patch["selected"].(bool); ok {
+		m.selected = v
+	}
+	if v, ok := patch["streaming"].(bool); ok {
+		m.streaming = v
+	}
+	// accept either "markdown" or "text"
+	if v, ok := patch["markdown"].(string); ok {
+		m.md = v
+	} else if v, ok := patch["text"].(string); ok {
+		m.md = v
+	}
 }
 
 func (m *MarkdownModel) View() string {
-    log.Trace().Str("component", "markdown_model").Str("phase", "view").Int("md_len", len(m.md)).Msg("calling model.View")
-    st := chatstyle.DefaultStyles()
-    sty := st.UnselectedMessage
-    if m.selected {
-        sty = st.SelectedMessage
-    }
+	log.Trace().Str("component", "markdown_model").Str("phase", "view").Int("md_len", len(m.md)).Msg("calling model.View")
+	st := chatstyle.DefaultStyles()
+	sty := st.UnselectedMessage
+	if m.selected {
+		sty = st.SelectedMessage
+	}
 
-    // approximate content width
-    frameW, _ := sty.GetFrameSize()
-    contentWidth := m.width - frameW - sty.GetHorizontalPadding()
-    if contentWidth < 0 { contentWidth = 0 }
+	// approximate content width
+	frameW, _ := sty.GetFrameSize()
+	contentWidth := m.width - frameW - sty.GetHorizontalPadding()
+	if contentWidth < 0 {
+		contentWidth = 0
+	}
 
-    // Render markdown with cache
-    var body string
-    if m.cachedRendered != "" && m.cachedWidth == contentWidth && m.cachedMD == m.md {
-        body = m.cachedRendered
-    } else {
-        if m.renderer != nil {
-            start := time.Now()
-            log.Trace().Str("component", "markdown_model").Str("phase", "view").Int("md_len", len(m.md)).Msg("calling glamour renderer")
-            if out, err := m.renderer.Render(strings.TrimSpace(m.md) + "\n"); err == nil {
-                body = strings.TrimSpace(out)
-            }
-            dur := time.Since(start)
-            log.Trace().Str("component", "markdown_model").Int("content_width", contentWidth).Int("md_len", len(m.md)).Dur("render_dur", dur).Msg("glamour render")
-        }
-        if body == "" { body = m.md }
-        m.cachedRendered = body
-        m.cachedWidth = contentWidth
-        m.cachedMD = m.md
-    }
+	// Render markdown with cache
+	var body string
+	if m.cachedRendered != "" && m.cachedWidth == contentWidth && m.cachedMD == m.md {
+		body = m.cachedRendered
+	} else {
+		if m.renderer != nil {
+			start := time.Now()
+			log.Trace().Str("component", "markdown_model").Str("phase", "view").Int("md_len", len(m.md)).Msg("calling glamour renderer")
+			if out, err := m.renderer.Render(strings.TrimSpace(m.md) + "\n"); err == nil {
+				body = strings.TrimSpace(out)
+			}
+			dur := time.Since(start)
+			log.Trace().Str("component", "markdown_model").Int("content_width", contentWidth).Int("md_len", len(m.md)).Dur("render_dur", dur).Msg("glamour render")
+		}
+		if body == "" {
+			body = m.md
+		}
+		m.cachedRendered = body
+		m.cachedWidth = contentWidth
+		m.cachedMD = m.md
+	}
 
-    // Box it
-    return sty.Width(m.width - sty.GetHorizontalPadding()).Render(body)
+	// Box it
+	return sty.Width(m.width - sty.GetHorizontalPadding()).Render(body)
 }
 
 type MarkdownFactory struct{ renderer *glamour.TermRenderer }
@@ -118,41 +122,41 @@ type MarkdownFactory struct{ renderer *glamour.TermRenderer }
 func (MarkdownFactory) Key() string  { return "renderer.markdown.v1" }
 func (MarkdownFactory) Kind() string { return "markdown" }
 func (f MarkdownFactory) NewEntityModel(initialProps map[string]any) timeline.EntityModel {
-    m := &MarkdownModel{renderer: f.renderer}
-    m.onProps(initialProps)
-    return m
+	m := &MarkdownModel{renderer: f.renderer}
+	m.onProps(initialProps)
+	return m
 }
 
 // NewMarkdownFactory constructs a factory with a shared glamour renderer.
 func NewMarkdownFactory() *MarkdownFactory {
-    var style string
-    if !term.IsTerminal(int(os.Stdout.Fd())) {
-        style = "notty"
-    } else if termenv.HasDarkBackground() {
-        style = "dark"
-    } else {
-        style = "light"
-    }
-    r, err := glamour.NewTermRenderer(
-        glamour.WithStandardStyle(style),
-        glamour.WithWordWrap(80),
-    )
-    if err != nil {
-        log.Error().Err(err).Str("component", "markdown_factory").Msg("failed to create glamour renderer")
-        r = nil
-    }
-    return &MarkdownFactory{renderer: r}
+	var style string
+	if !term.IsTerminal(int(os.Stdout.Fd())) {
+		style = "notty"
+	} else if termenv.HasDarkBackground() {
+		style = "dark"
+	} else {
+		style = "light"
+	}
+	r, err := glamour.NewTermRenderer(
+		glamour.WithStandardStyle(style),
+		glamour.WithWordWrap(80),
+	)
+	if err != nil {
+		log.Error().Err(err).Str("component", "markdown_factory").Msg("failed to create glamour renderer")
+		r = nil
+	}
+	return &MarkdownFactory{renderer: r}
 }
 
 var mdCodeBlockRe = regexp.MustCompile("(?s)```[a-zA-Z0-9_-]*\n(.*?)\n```")
 
 func mdExtractAllCodeBlocks(s string) []string {
-    matches := mdCodeBlockRe.FindAllStringSubmatch(s, -1)
-    var blocks []string
-    for _, m := range matches {
-        if len(m) >= 2 && m[1] != "" {
-            blocks = append(blocks, m[1])
-        }
-    }
-    return blocks
+	matches := mdCodeBlockRe.FindAllStringSubmatch(s, -1)
+	var blocks []string
+	for _, m := range matches {
+		if len(m) >= 2 && m[1] != "" {
+			blocks = append(blocks, m[1])
+		}
+	}
+	return blocks
 }

--- a/pkg/timeline/renderers/markdown_model.go
+++ b/pkg/timeline/renderers/markdown_model.go
@@ -109,10 +109,6 @@ func (m *MarkdownModel) View() string {
         m.cachedMD = m.md
     }
 
-    // Add selection indicator
-    if m.selected {
-        body = "▶ " + body
-    }
     // Box it
     return sty.Width(m.width - sty.GetHorizontalPadding()).Render(body)
 }

--- a/pkg/timeline/renderers/markdown_model.go
+++ b/pkg/timeline/renderers/markdown_model.go
@@ -1,15 +1,19 @@
 package renderers
 
 import (
-    "os"
-    "strings"
+	"os"
+	"regexp"
+	"strings"
 
-    tea "github.com/charmbracelet/bubbletea"
-    "github.com/charmbracelet/glamour"
-    "github.com/go-go-golems/bobatea/pkg/timeline"
-    chatstyle "github.com/go-go-golems/bobatea/pkg/timeline/chatstyle"
-    "github.com/muesli/termenv"
-    "golang.org/x/term"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/glamour"
+	"github.com/go-go-golems/bobatea/pkg/timeline"
+	chatstyle "github.com/go-go-golems/bobatea/pkg/timeline/chatstyle"
+	"github.com/muesli/termenv"
+	"github.com/rs/zerolog/log"
+	"golang.org/x/term"
 )
 
 // MarkdownModel renders markdown with glamour.
@@ -19,6 +23,10 @@ type MarkdownModel struct {
     streaming bool
     md        string
     renderer  *glamour.TermRenderer
+    // cache rendered output by width and content
+    cachedRendered string
+    cachedWidth    int
+    cachedMD       string
 }
 
 func (m *MarkdownModel) Init() tea.Cmd { return nil }
@@ -32,20 +40,24 @@ func (m *MarkdownModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
     case timeline.EntitySetSizeMsg:
         m.width = v.Width
     case timeline.EntityPropsUpdatedMsg:
+        log.Trace().Interface("msg", msg).Msg("updating markdown model")
         if v.Patch != nil {
             m.onProps(v.Patch)
         }
     case timeline.EntityCopyTextMsg:
         // Copy raw markdown text
+        log.Trace().Interface("msg", msg).Msg("copying markdown text")
         return m, func() tea.Msg { return timeline.CopyTextRequestedMsg{Text: m.md} }
     case timeline.EntityCopyCodeMsg:
-        blocks := extractAllCodeBlocks(m.md)
+        log.Trace().Interface("msg", msg).Msg("copying code")
+        blocks := mdExtractAllCodeBlocks(m.md)
         if len(blocks) > 0 {
             joined := strings.Join(blocks, "\n\n")
             return m, func() tea.Msg { return timeline.CopyCodeRequestedMsg{Code: joined} }
         }
         return m, func() tea.Msg { return timeline.CopyTextRequestedMsg{Text: m.md} }
     }
+    log.Trace().Interface("msg", msg).Msg("updating markdown model default case")
     return m, nil
 }
 
@@ -65,40 +77,54 @@ func (m *MarkdownModel) onProps(patch map[string]any) {
 }
 
 func (m *MarkdownModel) View() string {
+    log.Trace().Str("component", "markdown_model").Str("phase", "view").Int("md_len", len(m.md)).Msg("calling model.View")
     st := chatstyle.DefaultStyles()
     sty := st.UnselectedMessage
     if m.selected {
         sty = st.SelectedMessage
     }
 
-    if m.renderer == nil {
-        m.renderer = newGlamourRenderer()
-    }
+    // approximate content width
+    frameW, _ := sty.GetFrameSize()
+    contentWidth := m.width - frameW - sty.GetHorizontalPadding()
+    if contentWidth < 0 { contentWidth = 0 }
+
+    // Render markdown with cache
     var body string
-    if m.renderer != nil {
-        if out, err := m.renderer.Render(strings.TrimSpace(m.md) + "\n"); err == nil {
-            body = strings.TrimSpace(out)
+    if m.cachedRendered != "" && m.cachedWidth == contentWidth && m.cachedMD == m.md {
+        body = m.cachedRendered
+    } else {
+        if m.renderer != nil {
+            start := time.Now()
+            log.Trace().Str("component", "markdown_model").Str("phase", "view").Int("md_len", len(m.md)).Msg("calling glamour renderer")
+            if out, err := m.renderer.Render(strings.TrimSpace(m.md) + "\n"); err == nil {
+                body = strings.TrimSpace(out)
+            }
+            dur := time.Since(start)
+            log.Trace().Str("component", "markdown_model").Int("content_width", contentWidth).Int("md_len", len(m.md)).Dur("render_dur", dur).Msg("glamour render")
         }
-    }
-    if body == "" {
-        body = m.md
+        if body == "" { body = m.md }
+        m.cachedRendered = body
+        m.cachedWidth = contentWidth
+        m.cachedMD = m.md
     }
 
     // Box it
     return sty.Width(m.width - sty.GetHorizontalPadding()).Render(body)
 }
 
-type MarkdownFactory struct{}
+type MarkdownFactory struct{ renderer *glamour.TermRenderer }
 
 func (MarkdownFactory) Key() string  { return "renderer.markdown.v1" }
 func (MarkdownFactory) Kind() string { return "markdown" }
-func (MarkdownFactory) NewEntityModel(initialProps map[string]any) timeline.EntityModel {
-    m := &MarkdownModel{}
+func (f MarkdownFactory) NewEntityModel(initialProps map[string]any) timeline.EntityModel {
+    m := &MarkdownModel{renderer: f.renderer}
     m.onProps(initialProps)
     return m
 }
 
-func newGlamourRenderer() *glamour.TermRenderer {
+// NewMarkdownFactory constructs a factory with a shared glamour renderer.
+func NewMarkdownFactory() *MarkdownFactory {
     var style string
     if !term.IsTerminal(int(os.Stdout.Fd())) {
         style = "notty"
@@ -112,7 +138,21 @@ func newGlamourRenderer() *glamour.TermRenderer {
         glamour.WithWordWrap(80),
     )
     if err != nil {
-        return nil
+        log.Error().Err(err).Str("component", "markdown_factory").Msg("failed to create glamour renderer")
+        r = nil
     }
-    return r
+    return &MarkdownFactory{renderer: r}
+}
+
+var mdCodeBlockRe = regexp.MustCompile("(?s)```[a-zA-Z0-9_-]*\n(.*?)\n```")
+
+func mdExtractAllCodeBlocks(s string) []string {
+    matches := mdCodeBlockRe.FindAllStringSubmatch(s, -1)
+    var blocks []string
+    for _, m := range matches {
+        if len(m) >= 2 && m[1] != "" {
+            blocks = append(blocks, m[1])
+        }
+    }
+    return blocks
 }

--- a/pkg/timeline/renderers/structured_data_model.go
+++ b/pkg/timeline/renderers/structured_data_model.go
@@ -1,70 +1,70 @@
 package renderers
 
 import (
-    "encoding/json"
-    "fmt"
-    "strings"
+	"encoding/json"
+	"fmt"
+	"strings"
 
-    tea "github.com/charmbracelet/bubbletea"
-    "github.com/go-go-golems/bobatea/pkg/timeline"
-    chatstyle "github.com/go-go-golems/bobatea/pkg/timeline/chatstyle"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/go-go-golems/bobatea/pkg/timeline"
+	chatstyle "github.com/go-go-golems/bobatea/pkg/timeline/chatstyle"
 )
 
 // StructuredDataModel pretty-prints JSON or Go values as JSON.
 type StructuredDataModel struct {
-    width     int
-    selected  bool
-    raw       any
-    rendered  string
+	width    int
+	selected bool
+	raw      any
+	rendered string
 }
 
 func (m *StructuredDataModel) Init() tea.Cmd { return nil }
 
 func (m *StructuredDataModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
-    switch v := msg.(type) {
-    case timeline.EntitySelectedMsg:
-        m.selected = true
-    case timeline.EntityUnselectedMsg:
-        m.selected = false
-    case timeline.EntitySetSizeMsg:
-        m.width = v.Width
-    case timeline.EntityPropsUpdatedMsg:
-        if v.Patch != nil {
-            m.onProps(v.Patch)
-        }
-    case timeline.EntityCopyTextMsg:
-        return m, func() tea.Msg { return timeline.CopyTextRequestedMsg{Text: m.rendered} }
-    case timeline.EntityCopyCodeMsg:
-        return m, func() tea.Msg { return timeline.CopyCodeRequestedMsg{Code: m.rendered} }
-    }
-    return m, nil
+	switch v := msg.(type) {
+	case timeline.EntitySelectedMsg:
+		m.selected = true
+	case timeline.EntityUnselectedMsg:
+		m.selected = false
+	case timeline.EntitySetSizeMsg:
+		m.width = v.Width
+	case timeline.EntityPropsUpdatedMsg:
+		if v.Patch != nil {
+			m.onProps(v.Patch)
+		}
+	case timeline.EntityCopyTextMsg:
+		return m, func() tea.Msg { return timeline.CopyTextRequestedMsg{Text: m.rendered} }
+	case timeline.EntityCopyCodeMsg:
+		return m, func() tea.Msg { return timeline.CopyCodeRequestedMsg{Code: m.rendered} }
+	}
+	return m, nil
 }
 
 func (m *StructuredDataModel) onProps(patch map[string]any) {
-    if v, ok := patch["selected"].(bool); ok {
-        m.selected = v
-    }
-    // Accept either pre-rendered JSON string as "json" or Go value as "data".
-    if v, ok := patch["json"].(string); ok {
-        m.raw = v
-        m.rendered = prettyJSONFromString(v)
-        return
-    }
-    if v, ok := patch["data"]; ok {
-        m.raw = v
-        m.rendered = prettyJSONFromAny(v)
-        return
-    }
+	if v, ok := patch["selected"].(bool); ok {
+		m.selected = v
+	}
+	// Accept either pre-rendered JSON string as "json" or Go value as "data".
+	if v, ok := patch["json"].(string); ok {
+		m.raw = v
+		m.rendered = prettyJSONFromString(v)
+		return
+	}
+	if v, ok := patch["data"]; ok {
+		m.raw = v
+		m.rendered = prettyJSONFromAny(v)
+		return
+	}
 }
 
 func (m *StructuredDataModel) View() string {
-    st := chatstyle.DefaultStyles()
-    sty := st.UnselectedMessage
-    if m.selected {
-        sty = st.SelectedMessage
-    }
-    content := m.rendered
-    return sty.Width(m.width - sty.GetHorizontalPadding()).Render(content)
+	st := chatstyle.DefaultStyles()
+	sty := st.UnselectedMessage
+	if m.selected {
+		sty = st.SelectedMessage
+	}
+	content := m.rendered
+	return sty.Width(m.width - sty.GetHorizontalPadding()).Render(content)
 }
 
 type StructuredDataFactory struct{}
@@ -72,25 +72,25 @@ type StructuredDataFactory struct{}
 func (StructuredDataFactory) Key() string  { return "renderer.structured_data.v1" }
 func (StructuredDataFactory) Kind() string { return "structured_data" }
 func (StructuredDataFactory) NewEntityModel(initialProps map[string]any) timeline.EntityModel {
-    m := &StructuredDataModel{}
-    m.onProps(initialProps)
-    return m
+	m := &StructuredDataModel{}
+	m.onProps(initialProps)
+	return m
 }
 
 func prettyJSONFromString(s string) string {
-    var v any
-    if err := json.Unmarshal([]byte(s), &v); err != nil {
-        // Not JSON; return as-is wrapped in a JSON string for consistency
-        b, _ := json.Marshal(s)
-        return string(b)
-    }
-    return prettyJSONFromAny(v)
+	var v any
+	if err := json.Unmarshal([]byte(s), &v); err != nil {
+		// Not JSON; return as-is wrapped in a JSON string for consistency
+		b, _ := json.Marshal(s)
+		return string(b)
+	}
+	return prettyJSONFromAny(v)
 }
 
 func prettyJSONFromAny(v any) string {
-    b, err := json.MarshalIndent(v, "", "  ")
-    if err != nil {
-        return fmt.Sprintf("%v", v)
-    }
-    return strings.TrimSpace(string(b))
+	b, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		return fmt.Sprintf("%v", v)
+	}
+	return strings.TrimSpace(string(b))
 }

--- a/pkg/timeline/renderers/structured_data_model.go
+++ b/pkg/timeline/renderers/structured_data_model.go
@@ -1,0 +1,96 @@
+package renderers
+
+import (
+    "encoding/json"
+    "fmt"
+    "strings"
+
+    tea "github.com/charmbracelet/bubbletea"
+    "github.com/go-go-golems/bobatea/pkg/timeline"
+    chatstyle "github.com/go-go-golems/bobatea/pkg/timeline/chatstyle"
+)
+
+// StructuredDataModel pretty-prints JSON or Go values as JSON.
+type StructuredDataModel struct {
+    width     int
+    selected  bool
+    raw       any
+    rendered  string
+}
+
+func (m *StructuredDataModel) Init() tea.Cmd { return nil }
+
+func (m *StructuredDataModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+    switch v := msg.(type) {
+    case timeline.EntitySelectedMsg:
+        m.selected = true
+    case timeline.EntityUnselectedMsg:
+        m.selected = false
+    case timeline.EntitySetSizeMsg:
+        m.width = v.Width
+    case timeline.EntityPropsUpdatedMsg:
+        if v.Patch != nil {
+            m.onProps(v.Patch)
+        }
+    case timeline.EntityCopyTextMsg:
+        return m, func() tea.Msg { return timeline.CopyTextRequestedMsg{Text: m.rendered} }
+    case timeline.EntityCopyCodeMsg:
+        return m, func() tea.Msg { return timeline.CopyCodeRequestedMsg{Code: m.rendered} }
+    }
+    return m, nil
+}
+
+func (m *StructuredDataModel) onProps(patch map[string]any) {
+    if v, ok := patch["selected"].(bool); ok {
+        m.selected = v
+    }
+    // Accept either pre-rendered JSON string as "json" or Go value as "data".
+    if v, ok := patch["json"].(string); ok {
+        m.raw = v
+        m.rendered = prettyJSONFromString(v)
+        return
+    }
+    if v, ok := patch["data"]; ok {
+        m.raw = v
+        m.rendered = prettyJSONFromAny(v)
+        return
+    }
+}
+
+func (m *StructuredDataModel) View() string {
+    st := chatstyle.DefaultStyles()
+    sty := st.UnselectedMessage
+    if m.selected {
+        sty = st.SelectedMessage
+    }
+    return sty.Width(m.width - sty.GetHorizontalPadding()).Render(m.rendered)
+}
+
+type StructuredDataFactory struct{}
+
+func (StructuredDataFactory) Key() string  { return "renderer.structured_data.v1" }
+func (StructuredDataFactory) Kind() string { return "structured_data" }
+func (StructuredDataFactory) NewEntityModel(initialProps map[string]any) timeline.EntityModel {
+    m := &StructuredDataModel{}
+    m.onProps(initialProps)
+    return m
+}
+
+func prettyJSONFromString(s string) string {
+    var v any
+    if err := json.Unmarshal([]byte(s), &v); err != nil {
+        // Not JSON; return as-is wrapped in a JSON string for consistency
+        b, _ := json.Marshal(s)
+        return string(b)
+    }
+    return prettyJSONFromAny(v)
+}
+
+func prettyJSONFromAny(v any) string {
+    b, err := json.MarshalIndent(v, "", "  ")
+    if err != nil {
+        return fmt.Sprintf("%v", v)
+    }
+    return strings.TrimSpace(string(b))
+}
+

--- a/pkg/timeline/renderers/structured_data_model.go
+++ b/pkg/timeline/renderers/structured_data_model.go
@@ -64,9 +64,6 @@ func (m *StructuredDataModel) View() string {
         sty = st.SelectedMessage
     }
     content := m.rendered
-    if m.selected {
-        content = "▶ " + content
-    }
     return sty.Width(m.width - sty.GetHorizontalPadding()).Render(content)
 }
 

--- a/pkg/timeline/renderers/structured_data_model.go
+++ b/pkg/timeline/renderers/structured_data_model.go
@@ -63,7 +63,11 @@ func (m *StructuredDataModel) View() string {
     if m.selected {
         sty = st.SelectedMessage
     }
-    return sty.Width(m.width - sty.GetHorizontalPadding()).Render(m.rendered)
+    content := m.rendered
+    if m.selected {
+        content = "▶ " + content
+    }
+    return sty.Width(m.width - sty.GetHorizontalPadding()).Render(content)
 }
 
 type StructuredDataFactory struct{}
@@ -93,4 +97,3 @@ func prettyJSONFromAny(v any) string {
     }
     return strings.TrimSpace(string(b))
 }
-

--- a/pkg/timeline/renderers/structured_log_event_model.go
+++ b/pkg/timeline/renderers/structured_log_event_model.go
@@ -1,87 +1,107 @@
 package renderers
 
 import (
-    "strings"
+	"strings"
 
-    tea "github.com/charmbracelet/bubbletea"
-    "github.com/charmbracelet/lipgloss"
-    "github.com/go-go-golems/bobatea/pkg/timeline"
-    "github.com/rs/zerolog/log"
-    "gopkg.in/yaml.v3"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+	"github.com/go-go-golems/bobatea/pkg/timeline"
+	"github.com/rs/zerolog/log"
+	"gopkg.in/yaml.v3"
 )
 
 // StructuredLogEventModel renders a styled log header with a YAML body (always visible).
 type StructuredLogEventModel struct {
-    level    string
-    message  string
-    yamlStr  string
-    width    int
-    selected bool
+	level    string
+	message  string
+	yamlStr  string
+	width    int
+	selected bool
 }
 
 func (m *StructuredLogEventModel) Init() tea.Cmd { return nil }
 
 func (m *StructuredLogEventModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
-    switch v := msg.(type) {
-    case timeline.EntitySelectedMsg:
-        m.selected = true
-    case timeline.EntityUnselectedMsg:
-        m.selected = false
-    case timeline.EntitySetSizeMsg:
-        m.width = v.Width
-    case timeline.EntityPropsUpdatedMsg:
-        if v.Patch != nil { m.onProps(v.Patch) }
-    }
-    return m, nil
+	switch v := msg.(type) {
+	case timeline.EntitySelectedMsg:
+		m.selected = true
+	case timeline.EntityUnselectedMsg:
+		m.selected = false
+	case timeline.EntitySetSizeMsg:
+		m.width = v.Width
+	case timeline.EntityPropsUpdatedMsg:
+		if v.Patch != nil {
+			m.onProps(v.Patch)
+		}
+	}
+	return m, nil
 }
 
 func (m *StructuredLogEventModel) onProps(patch map[string]any) {
-    if v, ok := patch["level"].(string); ok { m.level = v }
-    if v, ok := patch["message"].(string); ok { m.message = v }
-    // Prefer explicit yaml string, else marshal data/metadata/fields
-    if v, ok := patch["yaml"].(string); ok {
-        m.yamlStr = strings.TrimSpace(v)
-        return
-    }
-    combined := map[string]any{}
-    if v, ok := patch["data"]; ok && v != nil { combined["data"] = v }
-    if v, ok := patch["metadata"]; ok && v != nil { combined["meta"] = v }
-    if v, ok := patch["fields"]; ok && v != nil { combined["fields"] = v }
-    if len(combined) > 0 {
-        if b, err := yaml.Marshal(combined); err == nil {
-            m.yamlStr = strings.TrimSpace(string(b))
-        } else {
-            log.Debug().Err(err).Str("component", "renderer").Str("kind", "structured_log_event").Msg("failed to marshal yaml")
-            m.yamlStr = ""
-        }
-    }
+	if v, ok := patch["level"].(string); ok {
+		m.level = v
+	}
+	if v, ok := patch["message"].(string); ok {
+		m.message = v
+	}
+	// Prefer explicit yaml string, else marshal data/metadata/fields
+	if v, ok := patch["yaml"].(string); ok {
+		m.yamlStr = strings.TrimSpace(v)
+		return
+	}
+	combined := map[string]any{}
+	if v, ok := patch["data"]; ok && v != nil {
+		combined["data"] = v
+	}
+	if v, ok := patch["metadata"]; ok && v != nil {
+		combined["meta"] = v
+	}
+	if v, ok := patch["fields"]; ok && v != nil {
+		combined["fields"] = v
+	}
+	if len(combined) > 0 {
+		if b, err := yaml.Marshal(combined); err == nil {
+			m.yamlStr = strings.TrimSpace(string(b))
+		} else {
+			log.Debug().Err(err).Str("component", "renderer").Str("kind", "structured_log_event").Msg("failed to marshal yaml")
+			m.yamlStr = ""
+		}
+	}
 }
 
 func (m *StructuredLogEventModel) View() string {
-    base := lipgloss.NewStyle().Padding(0, 1)
-    level := strings.ToUpper(strings.TrimSpace(m.level))
-    msg := strings.TrimSpace(m.message)
+	base := lipgloss.NewStyle().Padding(0, 1)
+	level := strings.ToUpper(strings.TrimSpace(m.level))
+	msg := strings.TrimSpace(m.message)
 
-    var lvlColor lipgloss.Color
-    switch strings.ToLower(level) {
-    case "error", "err": lvlColor = lipgloss.Color("196")
-    case "warn", "warning": lvlColor = lipgloss.Color("214")
-    case "debug": lvlColor = lipgloss.Color("243")
-    case "info": lvlColor = lipgloss.Color("39")
-    default: lvlColor = lipgloss.Color("245")
-    }
+	var lvlColor lipgloss.Color
+	switch strings.ToLower(level) {
+	case "error", "err":
+		lvlColor = lipgloss.Color("196")
+	case "warn", "warning":
+		lvlColor = lipgloss.Color("214")
+	case "debug":
+		lvlColor = lipgloss.Color("243")
+	case "info":
+		lvlColor = lipgloss.Color("39")
+	default:
+		lvlColor = lipgloss.Color("245")
+	}
 
-    lvl := lipgloss.NewStyle().Foreground(lvlColor).Bold(true).Render("[" + level + "]")
-    msgColor := lipgloss.Color("245"); if m.selected { msgColor = lipgloss.Color("252") }
-    msgStyled := lipgloss.NewStyle().Foreground(msgColor).Render(msg)
+	lvl := lipgloss.NewStyle().Foreground(lvlColor).Bold(true).Render("[" + level + "]")
+	msgColor := lipgloss.Color("245")
+	if m.selected {
+		msgColor = lipgloss.Color("252")
+	}
+	msgStyled := lipgloss.NewStyle().Foreground(msgColor).Render(msg)
 
-    header := strings.TrimSpace(strings.TrimSpace(lvl + " " + msgStyled))
-    body := header
-    if strings.TrimSpace(m.yamlStr) != "" {
-        // Ensure exactly one newline between header and YAML, no leading newline
-        body += "\n" + m.yamlStr
-    }
-    return base.Width(m.width - base.GetHorizontalPadding()).Render(body)
+	header := strings.TrimSpace(strings.TrimSpace(lvl + " " + msgStyled))
+	body := header
+	if strings.TrimSpace(m.yamlStr) != "" {
+		// Ensure exactly one newline between header and YAML, no leading newline
+		body += "\n" + m.yamlStr
+	}
+	return base.Width(m.width - base.GetHorizontalPadding()).Render(body)
 }
 
 type StructuredLogEventFactory struct{}
@@ -89,8 +109,7 @@ type StructuredLogEventFactory struct{}
 func (StructuredLogEventFactory) Key() string  { return "renderer.structured_log_event.v1" }
 func (StructuredLogEventFactory) Kind() string { return "structured_log_event" }
 func (StructuredLogEventFactory) NewEntityModel(initialProps map[string]any) timeline.EntityModel {
-    m := &StructuredLogEventModel{}
-    m.onProps(initialProps)
-    return m
+	m := &StructuredLogEventModel{}
+	m.onProps(initialProps)
+	return m
 }
-

--- a/pkg/timeline/renderers/structured_log_event_model.go
+++ b/pkg/timeline/renderers/structured_log_event_model.go
@@ -1,0 +1,96 @@
+package renderers
+
+import (
+    "strings"
+
+    tea "github.com/charmbracelet/bubbletea"
+    "github.com/charmbracelet/lipgloss"
+    "github.com/go-go-golems/bobatea/pkg/timeline"
+    "github.com/rs/zerolog/log"
+    "gopkg.in/yaml.v3"
+)
+
+// StructuredLogEventModel renders a styled log header with a YAML body (always visible).
+type StructuredLogEventModel struct {
+    level    string
+    message  string
+    yamlStr  string
+    width    int
+    selected bool
+}
+
+func (m *StructuredLogEventModel) Init() tea.Cmd { return nil }
+
+func (m *StructuredLogEventModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+    switch v := msg.(type) {
+    case timeline.EntitySelectedMsg:
+        m.selected = true
+    case timeline.EntityUnselectedMsg:
+        m.selected = false
+    case timeline.EntitySetSizeMsg:
+        m.width = v.Width
+    case timeline.EntityPropsUpdatedMsg:
+        if v.Patch != nil { m.onProps(v.Patch) }
+    }
+    return m, nil
+}
+
+func (m *StructuredLogEventModel) onProps(patch map[string]any) {
+    if v, ok := patch["level"].(string); ok { m.level = v }
+    if v, ok := patch["message"].(string); ok { m.message = v }
+    // Prefer explicit yaml string, else marshal data/metadata/fields
+    if v, ok := patch["yaml"].(string); ok {
+        m.yamlStr = strings.TrimSpace(v)
+        return
+    }
+    combined := map[string]any{}
+    if v, ok := patch["data"]; ok && v != nil { combined["data"] = v }
+    if v, ok := patch["metadata"]; ok && v != nil { combined["meta"] = v }
+    if v, ok := patch["fields"]; ok && v != nil { combined["fields"] = v }
+    if len(combined) > 0 {
+        if b, err := yaml.Marshal(combined); err == nil {
+            m.yamlStr = strings.TrimSpace(string(b))
+        } else {
+            log.Debug().Err(err).Str("component", "renderer").Str("kind", "structured_log_event").Msg("failed to marshal yaml")
+            m.yamlStr = ""
+        }
+    }
+}
+
+func (m *StructuredLogEventModel) View() string {
+    base := lipgloss.NewStyle().Padding(0, 1)
+    level := strings.ToUpper(strings.TrimSpace(m.level))
+    msg := strings.TrimSpace(m.message)
+
+    var lvlColor lipgloss.Color
+    switch strings.ToLower(level) {
+    case "error", "err": lvlColor = lipgloss.Color("196")
+    case "warn", "warning": lvlColor = lipgloss.Color("214")
+    case "debug": lvlColor = lipgloss.Color("243")
+    case "info": lvlColor = lipgloss.Color("39")
+    default: lvlColor = lipgloss.Color("245")
+    }
+
+    lvl := lipgloss.NewStyle().Foreground(lvlColor).Bold(true).Render("[" + level + "]")
+    msgColor := lipgloss.Color("245"); if m.selected { msgColor = lipgloss.Color("252") }
+    msgStyled := lipgloss.NewStyle().Foreground(msgColor).Render(msg)
+
+    header := strings.TrimSpace(strings.TrimSpace(lvl + " " + msgStyled))
+    body := header
+    if strings.TrimSpace(m.yamlStr) != "" {
+        // Ensure exactly one newline between header and YAML, no leading newline
+        body += "\n" + m.yamlStr
+    }
+    return base.Width(m.width - base.GetHorizontalPadding()).Render(body)
+}
+
+type StructuredLogEventFactory struct{}
+
+func (StructuredLogEventFactory) Key() string  { return "renderer.structured_log_event.v1" }
+func (StructuredLogEventFactory) Kind() string { return "structured_log_event" }
+func (StructuredLogEventFactory) NewEntityModel(initialProps map[string]any) timeline.EntityModel {
+    m := &StructuredLogEventModel{}
+    m.onProps(initialProps)
+    return m
+}
+

--- a/pkg/timeline/renderers/text_model.go
+++ b/pkg/timeline/renderers/text_model.go
@@ -76,6 +76,9 @@ func (m *TextModel) View() string {
         }
     }
     content := m.text.String()
+    if m.selected {
+        content = "▶ " + content
+    }
     return sty.Width(m.width - sty.GetHorizontalPadding()).Render(content)
 }
 
@@ -88,4 +91,3 @@ func (TextFactory) NewEntityModel(initialProps map[string]any) timeline.EntityMo
     m.onProps(initialProps)
     return m
 }
-

--- a/pkg/timeline/renderers/text_model.go
+++ b/pkg/timeline/renderers/text_model.go
@@ -76,9 +76,6 @@ func (m *TextModel) View() string {
         }
     }
     content := m.text.String()
-    if m.selected {
-        content = "▶ " + content
-    }
     return sty.Width(m.width - sty.GetHorizontalPadding()).Render(content)
 }
 

--- a/pkg/timeline/renderers/text_model.go
+++ b/pkg/timeline/renderers/text_model.go
@@ -1,82 +1,82 @@
 package renderers
 
 import (
-    "strings"
+	"strings"
 
-    tea "github.com/charmbracelet/bubbletea"
-    "github.com/go-go-golems/bobatea/pkg/timeline"
-    chatstyle "github.com/go-go-golems/bobatea/pkg/timeline/chatstyle"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/go-go-golems/bobatea/pkg/timeline"
+	chatstyle "github.com/go-go-golems/bobatea/pkg/timeline/chatstyle"
 )
 
 // TextModel renders plain text with optional streaming and error styling.
 type TextModel struct {
-    width     int
-    selected  bool
-    isError   bool
-    streaming bool
-    text      strings.Builder
+	width     int
+	selected  bool
+	isError   bool
+	streaming bool
+	text      strings.Builder
 }
 
 func (m *TextModel) Init() tea.Cmd { return nil }
 
 func (m *TextModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
-    switch v := msg.(type) {
-    case timeline.EntitySelectedMsg:
-        m.selected = true
-    case timeline.EntityUnselectedMsg:
-        m.selected = false
-    case timeline.EntitySetSizeMsg:
-        m.width = v.Width
-    case timeline.EntityPropsUpdatedMsg:
-        if v.Patch != nil {
-            m.onProps(v.Patch)
-        }
-    case timeline.EntityCopyTextMsg:
-        txt := m.text.String()
-        return m, func() tea.Msg { return timeline.CopyTextRequestedMsg{Text: txt} }
-    case timeline.EntityCopyCodeMsg:
-        // Fallback to plain text copy
-        txt := m.text.String()
-        return m, func() tea.Msg { return timeline.CopyTextRequestedMsg{Text: txt} }
-    }
-    return m, nil
+	switch v := msg.(type) {
+	case timeline.EntitySelectedMsg:
+		m.selected = true
+	case timeline.EntityUnselectedMsg:
+		m.selected = false
+	case timeline.EntitySetSizeMsg:
+		m.width = v.Width
+	case timeline.EntityPropsUpdatedMsg:
+		if v.Patch != nil {
+			m.onProps(v.Patch)
+		}
+	case timeline.EntityCopyTextMsg:
+		txt := m.text.String()
+		return m, func() tea.Msg { return timeline.CopyTextRequestedMsg{Text: txt} }
+	case timeline.EntityCopyCodeMsg:
+		// Fallback to plain text copy
+		txt := m.text.String()
+		return m, func() tea.Msg { return timeline.CopyTextRequestedMsg{Text: txt} }
+	}
+	return m, nil
 }
 
 func (m *TextModel) onProps(patch map[string]any) {
-    if v, ok := patch["selected"].(bool); ok {
-        m.selected = v
-    }
-    if v, ok := patch["is_error"].(bool); ok {
-        m.isError = v
-    }
-    if v, ok := patch["streaming"].(bool); ok {
-        m.streaming = v
-    }
-    if v, ok := patch["text"].(string); ok {
-        // replace content
-        m.text.Reset()
-        m.text.WriteString(v)
-    }
-    if v, ok := patch["append"].(string); ok {
-        m.text.WriteString(v)
-    }
+	if v, ok := patch["selected"].(bool); ok {
+		m.selected = v
+	}
+	if v, ok := patch["is_error"].(bool); ok {
+		m.isError = v
+	}
+	if v, ok := patch["streaming"].(bool); ok {
+		m.streaming = v
+	}
+	if v, ok := patch["text"].(string); ok {
+		// replace content
+		m.text.Reset()
+		m.text.WriteString(v)
+	}
+	if v, ok := patch["append"].(string); ok {
+		m.text.WriteString(v)
+	}
 }
 
 func (m *TextModel) View() string {
-    st := chatstyle.DefaultStyles()
-    sty := st.UnselectedMessage
-    if m.selected {
-        sty = st.SelectedMessage
-    }
-    if m.isError {
-        if m.selected {
-            sty = st.ErrorSelected
-        } else {
-            sty = st.ErrorMessage
-        }
-    }
-    content := m.text.String()
-    return sty.Width(m.width - sty.GetHorizontalPadding()).Render(content)
+	st := chatstyle.DefaultStyles()
+	sty := st.UnselectedMessage
+	if m.selected {
+		sty = st.SelectedMessage
+	}
+	if m.isError {
+		if m.selected {
+			sty = st.ErrorSelected
+		} else {
+			sty = st.ErrorMessage
+		}
+	}
+	content := m.text.String()
+	return sty.Width(m.width - sty.GetHorizontalPadding()).Render(content)
 }
 
 type TextFactory struct{}
@@ -84,7 +84,7 @@ type TextFactory struct{}
 func (TextFactory) Key() string  { return "renderer.text.v1" }
 func (TextFactory) Kind() string { return "text" }
 func (TextFactory) NewEntityModel(initialProps map[string]any) timeline.EntityModel {
-    m := &TextModel{}
-    m.onProps(initialProps)
-    return m
+	m := &TextModel{}
+	m.onProps(initialProps)
+	return m
 }

--- a/pkg/timeline/renderers/text_model.go
+++ b/pkg/timeline/renderers/text_model.go
@@ -1,0 +1,91 @@
+package renderers
+
+import (
+    "strings"
+
+    tea "github.com/charmbracelet/bubbletea"
+    "github.com/go-go-golems/bobatea/pkg/timeline"
+    chatstyle "github.com/go-go-golems/bobatea/pkg/timeline/chatstyle"
+)
+
+// TextModel renders plain text with optional streaming and error styling.
+type TextModel struct {
+    width     int
+    selected  bool
+    isError   bool
+    streaming bool
+    text      strings.Builder
+}
+
+func (m *TextModel) Init() tea.Cmd { return nil }
+
+func (m *TextModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+    switch v := msg.(type) {
+    case timeline.EntitySelectedMsg:
+        m.selected = true
+    case timeline.EntityUnselectedMsg:
+        m.selected = false
+    case timeline.EntitySetSizeMsg:
+        m.width = v.Width
+    case timeline.EntityPropsUpdatedMsg:
+        if v.Patch != nil {
+            m.onProps(v.Patch)
+        }
+    case timeline.EntityCopyTextMsg:
+        txt := m.text.String()
+        return m, func() tea.Msg { return timeline.CopyTextRequestedMsg{Text: txt} }
+    case timeline.EntityCopyCodeMsg:
+        // Fallback to plain text copy
+        txt := m.text.String()
+        return m, func() tea.Msg { return timeline.CopyTextRequestedMsg{Text: txt} }
+    }
+    return m, nil
+}
+
+func (m *TextModel) onProps(patch map[string]any) {
+    if v, ok := patch["selected"].(bool); ok {
+        m.selected = v
+    }
+    if v, ok := patch["is_error"].(bool); ok {
+        m.isError = v
+    }
+    if v, ok := patch["streaming"].(bool); ok {
+        m.streaming = v
+    }
+    if v, ok := patch["text"].(string); ok {
+        // replace content
+        m.text.Reset()
+        m.text.WriteString(v)
+    }
+    if v, ok := patch["append"].(string); ok {
+        m.text.WriteString(v)
+    }
+}
+
+func (m *TextModel) View() string {
+    st := chatstyle.DefaultStyles()
+    sty := st.UnselectedMessage
+    if m.selected {
+        sty = st.SelectedMessage
+    }
+    if m.isError {
+        if m.selected {
+            sty = st.ErrorSelected
+        } else {
+            sty = st.ErrorMessage
+        }
+    }
+    content := m.text.String()
+    return sty.Width(m.width - sty.GetHorizontalPadding()).Render(content)
+}
+
+type TextFactory struct{}
+
+func (TextFactory) Key() string  { return "renderer.text.v1" }
+func (TextFactory) Kind() string { return "text" }
+func (TextFactory) NewEntityModel(initialProps map[string]any) timeline.EntityModel {
+    m := &TextModel{}
+    m.onProps(initialProps)
+    return m
+}
+

--- a/pkg/timeline/shell.go
+++ b/pkg/timeline/shell.go
@@ -50,8 +50,8 @@ func (s *Shell) AtBottom() bool { return s.viewport.AtBottom() }
 
 // View returns the current timeline view as rendered within the viewport.
 func (s *Shell) View() string {
-    // Content is updated via RefreshView; avoid recomputing on every View call
-    return s.viewport.View()
+	// Content is updated via RefreshView; avoid recomputing on every View call
+	return s.viewport.View()
 }
 
 // UpdateViewport forwards messages to the viewport (e.g., scrolling) and returns any command.
@@ -68,14 +68,14 @@ func (s *Shell) UpdateViewport(msg tea.Msg) tea.Cmd {
 
 // RefreshView regenerates the viewport content and optionally scrolls to bottom.
 func (s *Shell) RefreshView(goToBottom bool) {
-    start := time.Now()
-    v := s.ctrl.View()
-    s.viewport.SetContent(v)
-    if goToBottom || s.scrollToBottom {
-        s.viewport.GotoBottom()
-    }
-    dur := time.Since(start)
-    log.Debug().Str("component", "timeline_shell").Str("op", "RefreshView").Dur("dur", dur).Int("len", len(v)).Msg("refreshed viewport content")
+	start := time.Now()
+	v := s.ctrl.View()
+	s.viewport.SetContent(v)
+	if goToBottom || s.scrollToBottom {
+		s.viewport.GotoBottom()
+	}
+	dur := time.Since(start)
+	log.Debug().Str("component", "timeline_shell").Str("op", "RefreshView").Dur("dur", dur).Int("len", len(v)).Msg("refreshed viewport content")
 }
 
 // GotoBottom forces the viewport to scroll to the bottom.

--- a/pkg/timeline/shell.go
+++ b/pkg/timeline/shell.go
@@ -50,8 +50,8 @@ func (s *Shell) AtBottom() bool { return s.viewport.AtBottom() }
 
 // View returns the current timeline view as rendered within the viewport.
 func (s *Shell) View() string {
-	s.viewport.SetContent(s.ctrl.View())
-	return s.viewport.View()
+    // Content is updated via RefreshView; avoid recomputing on every View call
+    return s.viewport.View()
 }
 
 // UpdateViewport forwards messages to the viewport (e.g., scrolling) and returns any command.
@@ -68,11 +68,14 @@ func (s *Shell) UpdateViewport(msg tea.Msg) tea.Cmd {
 
 // RefreshView regenerates the viewport content and optionally scrolls to bottom.
 func (s *Shell) RefreshView(goToBottom bool) {
-	v := s.ctrl.View()
-	s.viewport.SetContent(v)
-	if goToBottom || s.scrollToBottom {
-		s.viewport.GotoBottom()
-	}
+    start := time.Now()
+    v := s.ctrl.View()
+    s.viewport.SetContent(v)
+    if goToBottom || s.scrollToBottom {
+        s.viewport.GotoBottom()
+    }
+    dur := time.Since(start)
+    log.Debug().Str("component", "timeline_shell").Str("op", "RefreshView").Dur("dur", dur).Int("len", len(v)).Msg("refreshed viewport content")
 }
 
 // GotoBottom forces the viewport to scroll to the bottom.

--- a/pkg/timeline/wm_forwarder.go
+++ b/pkg/timeline/wm_forwarder.go
@@ -1,0 +1,39 @@
+package timeline
+
+import (
+    "encoding/json"
+
+    "github.com/ThreeDotsLabs/watermill/message"
+    tea "github.com/charmbracelet/bubbletea"
+    "github.com/go-go-golems/bobatea/pkg/eventbus"
+)
+
+// RegisterUIForwarder adds a handler that forwards ui.entities to a tea.Program as Bubble Tea messages.
+func RegisterUIForwarder(bus *eventbus.Bus, p *tea.Program) {
+    bus.AddHandler("ui-forward", eventbus.TopicUIEntities, func(msg *message.Message) error {
+        defer msg.Ack()
+        var env struct {
+            Type    string          `json:"type"`
+            Payload json.RawMessage `json:"payload"`
+        }
+        if err := json.Unmarshal(msg.Payload, &env); err != nil {
+            return err
+        }
+        switch env.Type {
+        case "timeline.created":
+            var e UIEntityCreated
+            if err := json.Unmarshal(env.Payload, &e); err == nil { p.Send(e) }
+        case "timeline.updated":
+            var e UIEntityUpdated
+            if err := json.Unmarshal(env.Payload, &e); err == nil { p.Send(e) }
+        case "timeline.completed":
+            var e UIEntityCompleted
+            if err := json.Unmarshal(env.Payload, &e); err == nil { p.Send(e) }
+        case "timeline.deleted":
+            var e UIEntityDeleted
+            if err := json.Unmarshal(env.Payload, &e); err == nil { p.Send(e) }
+        }
+        return nil
+    })
+}
+

--- a/pkg/timeline/wm_forwarder.go
+++ b/pkg/timeline/wm_forwarder.go
@@ -1,39 +1,46 @@
 package timeline
 
 import (
-    "encoding/json"
+	"encoding/json"
 
-    "github.com/ThreeDotsLabs/watermill/message"
-    tea "github.com/charmbracelet/bubbletea"
-    "github.com/go-go-golems/bobatea/pkg/eventbus"
+	"github.com/ThreeDotsLabs/watermill/message"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/go-go-golems/bobatea/pkg/eventbus"
 )
 
 // RegisterUIForwarder adds a handler that forwards ui.entities to a tea.Program as Bubble Tea messages.
 func RegisterUIForwarder(bus *eventbus.Bus, p *tea.Program) {
-    bus.AddHandler("ui-forward", eventbus.TopicUIEntities, func(msg *message.Message) error {
-        defer msg.Ack()
-        var env struct {
-            Type    string          `json:"type"`
-            Payload json.RawMessage `json:"payload"`
-        }
-        if err := json.Unmarshal(msg.Payload, &env); err != nil {
-            return err
-        }
-        switch env.Type {
-        case "timeline.created":
-            var e UIEntityCreated
-            if err := json.Unmarshal(env.Payload, &e); err == nil { p.Send(e) }
-        case "timeline.updated":
-            var e UIEntityUpdated
-            if err := json.Unmarshal(env.Payload, &e); err == nil { p.Send(e) }
-        case "timeline.completed":
-            var e UIEntityCompleted
-            if err := json.Unmarshal(env.Payload, &e); err == nil { p.Send(e) }
-        case "timeline.deleted":
-            var e UIEntityDeleted
-            if err := json.Unmarshal(env.Payload, &e); err == nil { p.Send(e) }
-        }
-        return nil
-    })
+	bus.AddHandler("ui-forward", eventbus.TopicUIEntities, func(msg *message.Message) error {
+		defer msg.Ack()
+		var env struct {
+			Type    string          `json:"type"`
+			Payload json.RawMessage `json:"payload"`
+		}
+		if err := json.Unmarshal(msg.Payload, &env); err != nil {
+			return err
+		}
+		switch env.Type {
+		case "timeline.created":
+			var e UIEntityCreated
+			if err := json.Unmarshal(env.Payload, &e); err == nil {
+				p.Send(e)
+			}
+		case "timeline.updated":
+			var e UIEntityUpdated
+			if err := json.Unmarshal(env.Payload, &e); err == nil {
+				p.Send(e)
+			}
+		case "timeline.completed":
+			var e UIEntityCompleted
+			if err := json.Unmarshal(env.Payload, &e); err == nil {
+				p.Send(e)
+			}
+		case "timeline.deleted":
+			var e UIEntityDeleted
+			if err := json.Unmarshal(env.Payload, &e); err == nil {
+				p.Send(e)
+			}
+		}
+		return nil
+	})
 }
-

--- a/ttmp/2025-08-31/01-analysis-of-the-timeline-and-repl-packages-and-suggestions-for-architecture.md
+++ b/ttmp/2025-08-31/01-analysis-of-the-timeline-and-repl-packages-and-suggestions-for-architecture.md
@@ -1,0 +1,292 @@
+# Timeline + REPL: Analysis and Architecture Proposals
+
+This document analyzes the timeline and REPL components in this repository and proposes an architecture to combine them for a richer REPL experience. The goal is to adopt the append-only, entity-driven timeline architecture to render REPL interactions as first-class entities with interactive, customizable widgets.
+
+
+## 1) What Exists Today
+
+### Timeline (Turn-centric UI)
+- Append-only visualization: Entities are created, updated, completed, deleted. Ordering follows creation time.
+- Decoupled rendering: Renderers are Bubble Tea models that receive props/patches and render directly (no stateless renderers or caches).
+- Controller + Registry:
+  - `Controller` manages entity lifecycle, selection/focus, routing messages to entity models, and rendering a viewport-friendly view.
+  - `Registry` maps `RendererDescriptor{Key, Kind}` to factories producing interactive entity models.
+- Entity identity and lifecycle:
+  - `EntityID{RunID, TurnID, BlockID, LocalID, Kind}` + `RendererDescriptor{Key, Kind}`
+  - Messages: `UIEntityCreated`, `UIEntityUpdated`, `UIEntityCompleted`, `UIEntityDeleted`
+  - Controller also routes selection/focus and copy requests (`EntityCopyTextMsg`, `EntityCopyCodeMsg`).
+- Renderers present:
+  - `llm_text` (markdown, role, streaming animation, metadata footer, code copy)
+  - `tool_calls_panel` (compact panel of tool calls)
+  - `plain` (debugging: prints props)
+- Demo (`cmd/timeline-demo`): keyboard-driven example that streams text and a tools panel; shows controller APIs, selection, and copy flows.
+
+### REPL
+- Embeddable Bubble Tea REPL with a pluggable `Evaluator` interface:
+  - `Evaluate(ctx, code) (string, error)` + getters for prompt/name/multiline/extension
+  - History, themes/styles, multiline, external editor, slash commands, async via Tea commands
+  - View prints a traditional linear transcript of input/output.
+- Examples include basic usage, custom evaluators, custom themes, multipane embedding.
+
+
+## 2) Observations From Examples
+
+- Timeline demo shows how entities can stream, be selected/focused, and expose secondary actions (copy text/code). It is well-suited to visualize turns or steps.
+- REPL examples show classic REPL behavior (input → evaluation → output), with room for richer outputs (tables, panels, progress, tool-call summaries), but current rendering is monolithic.
+- The sparkline package exists and could power REPL performance widgets.
+
+
+## 3) Proposed Vision: A Timeline-First REPL
+
+Move the REPL from a single flat transcript to a timeline of entities. Each user input and its outputs become a “turn” comprised of multiple entities:
+- Input entity (the code or command the user submitted)
+- Output entities (stdout, stderr, result, logs, tool-call summaries, structured artifacts)
+- Status entities (progress, timing, resource usage, metadata)
+
+The REPL view becomes:
+- Top: timeline viewport (append-only, selectable, interactive entities)
+- Bottom: REPL input line (or multiline editor) controlling new turns
+- Controller mediates selection/focus; entities can handle their own key interactions when focused (expand/collapse, copy, rerun, etc.)
+
+Benefits:
+- Rich per-result widgets (tables, diffs, inspectors, plots, markdown) instead of plain text
+- Clear separation of concerns: evaluators emit events, timeline renders them
+- Easy extension: registering new renderers adds capabilities without rewriting REPL core
+
+
+## 4) Entity Taxonomy for REPL
+
+Suggested entity kinds and their expected props. Each should have a corresponding renderer factory.
+
+- `repl_input`
+  - Props: `prompt`, `code`, `language`, `cwd`, `timestamp`
+  - Widget: monospace boxed code block, copyable, optional syntax highlighting
+- `repl_stdout`
+  - Props: `text`, `streaming`, `chunks` (append), `timestamp`
+  - Widget: stream-aware text area, optional copy-as-text
+- `repl_stderr`
+  - Props: `text`, `streaming`, `severity`, `timestamp`
+  - Widget: emphasized/error style, stream-aware
+- `repl_result_markdown`
+  - Props: `markdown`, `metadata` (duration, exit-code), `streaming`
+  - Widget: based on `llm_text` renderer; supports code copy
+- `repl_tool_calls`
+  - Props: `calls: []{id,name,status,result?}`, `summary`
+  - Widget: reuse/extend `tool_calls_panel`
+- `repl_progress`
+  - Props: `label`, `current`, `total`, `phase`, `spinner`
+  - Widget: progress bar + spinner line
+- `repl_perf`
+  - Props: `durations_ms: []int`, `last_ms`, `success_rate`
+  - Widget: sparkline + summary footer (use `pkg/sparkline`)
+- `repl_table`
+  - Props: `headers: []string`, `rows: [][]string`, `max_rows`, `truncated`
+  - Widget: compact table, scroll or expand when focused
+- `repl_diff`
+  - Props: `a_label`, `b_label`, `diff_text` (unified), `stats`
+  - Widget: colored unified diff with expand/collapse
+- `repl_fs_event`
+  - Props: `path`, `op` (created/updated/deleted), `size`, `preview?`
+  - Widget: compact line, expandable details
+- `repl_shell_cmd`
+  - Props: `command`, `cwd`, `exit_code`, `stdout`, `stderr`, `duration_ms`
+  - Widget: command header line, foldable stdout/stderr sections
+- `repl_inspector`
+  - Props: `object_kind`, `summary`, `details` (JSON), `expandable`
+  - Widget: pretty-printed JSON or tree explorer
+
+The base `plain` renderer is a good fallback for any entity kind during development.
+
+
+## 5) Event Flow and Mapping
+
+Introduce a bridge layer (adapter) that maps REPL lifecycle and evaluator signals to timeline lifecycle messages.
+
+- On user submit:
+  - Create a new TurnID (e.g., timestamp or incrementing counter)
+  - Emit `UIEntityCreated{ID: {TurnID, LocalID: "input", Kind: "repl_input"}, Props: {prompt, code, language, ...}}`
+- During evaluation:
+  - For streaming stdout/stderr from evaluator, emit `UIEntityCreated` for each stream entity upon first chunk, then `UIEntityUpdated` with `Patch: {chunks: append(...), text: concat}` on subsequent chunks
+  - For progress, `repl_progress` updates via `UIEntityUpdated` with `current/total`
+- On result:
+  - Emit one or more result entities: `repl_result_markdown`, `repl_table`, `repl_diff`, `repl_inspector`, etc.
+  - Emit `UIEntityCompleted` for all in-flight entities to freeze their state
+- On failure:
+  - Emit/complete a `repl_stderr` entity (or result with error styling) with error message and metadata (exit code, duration)
+
+IDs and labels:
+- Use `EntityID{TurnID: <eval-id>, LocalID: <sequence>, Kind: <...>}`
+- Optionally include `Labels` (e.g., language, evaluator name) to aid filtering.
+
+
+## 6) REPL Model Integration Patterns
+
+Two viable integration strategies:
+
+1) Non-invasive Bridge (Adapter) around current REPL
+- Keep the existing REPL UI intact for input. Replace/augment its transcript printing by emitting timeline events to a co-located timeline viewport above it.
+- Pros: minimal changes; preserves existing API; quick path to value.
+- Cons: the history list inside REPL becomes redundant; better to phase it out in favor of timeline entities.
+
+2) Timeline-First REPL (Refactor)
+- Make the timeline the source of truth for the transcript. The REPL’s `View()` renders only the input line and status bar; all previous outputs come from the timeline controller’s `View()`.
+- Pros: single rendering path, richer widgets, selection/focus support out of the box.
+- Cons: larger refactor; requires an adapter for evaluators to emit structured/streaming events.
+
+Recommendation: Start with (1), then evolve into (2).
+
+
+## 7) Evaluator Extensions for Rich Output
+
+The current `Evaluator` returns a single `(string, error)`. To enable structured, streaming outputs:
+
+- Add an optional interface:
+  ```go
+  type StreamingEvaluator interface {
+    EvaluateStream(ctx context.Context, code string, emit func(Event)) error
+  }
+
+  // Example event union
+  type Event struct {
+    Kind string // stdout, stderr, result_markdown, table, diff, progress, tool_call
+    Props map[string]any
+  }
+  ```
+- The REPL bridge detects `StreamingEvaluator` and, if present, forwards events to the timeline controller by mapping to `UIEntityCreated/Updated/Completed`.
+- For non-streaming evaluators, the bridge wraps the output into a single `repl_result_markdown` entity.
+
+Note: This maintains backward compatibility while enabling structured outputs.
+
+
+## 8) Renderer/Widget Catalog and Reuse
+
+- Reuse `llm_text` renderer for `repl_result_markdown` immediately (it already supports markdown, code copy, streaming indicator, metadata footer). Set `role` to `"result"` and use `metadata` for timing/exit-code.
+- Reuse/extend `tool_calls_panel` for `repl_tool_calls` to summarize steps a REPL/evaluator takes (e.g., shell commands, network calls, sub-invocations).
+- Build new renderers incrementally:
+  - `repl_stdout` and `repl_stderr`: simple text models with distinct styles and stream awareness.
+  - `repl_progress`: single-line progress with spinner and right-aligned metadata (ETA, current/total).
+  - `repl_perf`: small sparkline using `pkg/sparkline` to visualize recent eval durations.
+  - `repl_table`: compact table; when selected/focused, allow horizontal scrolling or expand-in-place.
+  - `repl_diff`: unified diff; expose key to toggle context.
+  - `repl_shell_cmd`: header + foldable stdout/stderr sub-sections; keys to copy stdout/stderr separately.
+
+All renderers should implement copy semantics via `EntityCopyTextMsg`/`EntityCopyCodeMsg` where applicable.
+
+
+## 9) Keyboard UX and Focus Model
+
+Leverage the timeline controller’s selection and entering/focus model:
+- Global keys:
+  - Up/Down: move selection across entities
+  - Enter: toggle “entering” mode; while entering, route keys to the selected entity model
+  - Tab/Shift+Tab: allow compact toggles even outside entering
+  - c: copy code (controller sends `EntityCopyCodeMsg` to selected entity; renderer chooses best content)
+  - y: copy text (send `EntityCopyTextMsg`)
+- Entity-level keys (handled inside models when focused):
+  - Expand/collapse, switch tabs (stdout/stderr), page through tables, toggle diff context, etc.
+
+The input field remains always accessible; consider a key (e.g., Esc) to exit entity focus and return to input.
+
+
+## 10) Minimal Implementation Plan
+
+Phase 1: Bridge and Basic Widgets
+- Add a new package `pkg/repltimeline` (or integrate into `pkg/repl`) that:
+  - Creates a `timeline.Controller` + `timeline.Registry`
+  - Registers `llm_text`, `tool_calls_panel`, and `plain`
+  - Exposes helpers like `EmitInput(turnID, code)`, `EmitStdout(turnID, chunk)`, `EmitResult(turnID, md, meta)`
+- Update the REPL example app to render the timeline viewport above the input line and route keys to both (viewport + input).
+- Map evaluation completion to a `repl_result_markdown` using `llm_text` now.
+
+Phase 2: Structured/Streaming Evaluations
+- Introduce `StreamingEvaluator` interface and adapt the JS, Shell examples to stream stdout/stderr chunks and progress.
+- Implement `repl_stdout`/`repl_stderr` renderers.
+
+Phase 3: Enrich with Widgets
+- Add `repl_shell_cmd`, `repl_progress`, `repl_perf` (sparkline), and `repl_table`.
+- Provide reusable helpers to convert common evaluator outputs (e.g., CSV/JSON) into tables or inspectors.
+
+Phase 4: Make Timeline the Primary Transcript
+- Remove the REPL’s inline history rendering; rely solely on timeline entities.
+- Add commands to interact with prior turns (e.g., “rerun this input”, “open in editor”, “copy result”), leveraging selection.
+
+
+## 11) Data Contracts and Props
+
+Standardize props for cross-renderer consistency:
+- Every entity supports `selected` boolean (controller already injects it) and uses a common style system (`chatstyle.DefaultStyles()` is a good baseline).
+- Timestamps: prefer `StartedAt` from `UIEntityCreated`. Add `duration_ms` to result/progress entities.
+- Copy behavior: renderers implement copy-message handling and choose the best payload (e.g., fenced code blocks for markdown).
+
+
+## 12) Example: Shell Evaluator → Timeline
+
+Pseudocode for a streaming shell evaluator emitting stdout/stderr and a final result:
+
+```go
+func (e *ShellStreamingEvaluator) EvaluateStream(ctx context.Context, code string, emit func(Event)) error {
+  turnID := newTurnID()
+  emit(Event{Kind: "repl_input", Props: map[string]any{"prompt": e.GetPrompt(), "code": code, "cwd": e.workingDir}})
+
+  // Create streams lazily on first chunk
+  var outCreated, errCreated bool
+  var start = time.Now()
+
+  cmd := exec.CommandContext(ctx, "bash", "-c", code)
+  // wire stdout/stderr readers...
+  go readLines(cmd.Stdout, func(line string) {
+    if !outCreated { emit(Event{Kind: "repl_stdout", Props: map[string]any{"text": "", "streaming": true}}); outCreated = true }
+    emit(Event{Kind: "repl_stdout", Props: map[string]any{"append": line + "\n"}})
+  })
+  go readLines(cmd.Stderr, func(line string) {
+    if !errCreated { emit(Event{Kind: "repl_stderr", Props: map[string]any{"text": "", "streaming": true}}); errCreated = true }
+    emit(Event{Kind: "repl_stderr", Props: map[string]any{"append": line + "\n"}})
+  })
+
+  err := cmd.Run()
+  dur := time.Since(start)
+  exitCode := 0
+  if err != nil { exitCode = extractExitCode(err) }
+
+  emit(Event{Kind: "repl_result_markdown", Props: map[string]any{
+    "markdown": fmt.Sprintf("Exit: %d\nDuration: %s", exitCode, dur),
+    "metadata": map[string]any{"exit_code": exitCode, "duration_ms": dur.Milliseconds()},
+  }})
+  return err
+}
+```
+
+The bridge converts Events to timeline messages, maintaining a consistent TurnID for grouping.
+
+
+## 13) Theming and Cohesion
+
+- Use `chatstyle` as a base for entities to ensure consistent borders, padding, and selection/focus states.
+- Expose a REPL theme that maps to entity styles (e.g., `stdout` vs `stderr` colors).
+- Propagate global theme via `Controller.SetTheme()` and have models react by updating their styles.
+
+
+## 14) Testing and Debugging
+
+- Leverage the timeline demo’s logging strategy to inspect message flow.
+- Use the `plain` renderer during development to validate props and lifecycle.
+- Add a debug command `/dump` to emit a `plain` entity with the current evaluator context.
+
+
+## 15) Risks and Mitigations
+
+- Complexity creep: Start with the bridge, reuse existing renderers, and grow incrementally.
+- Streaming backpressure: Use buffered channels and coalesce updates (e.g., batch stdout lines).
+- Width/height handling: Controller already dispatches `EntitySetSizeMsg`; ensure renderers wrap content.
+- Copy behavior variance: Standardize copy semantics across renderers and document keybindings.
+
+
+## 16) Summary
+
+- The timeline architecture is a natural fit for a modern REPL: append-only turns, interactive entities, and rich widgets.
+- Begin with a bridge that surfaces REPL interactions as timeline entities using existing `llm_text` and `tool_calls_panel` renderers.
+- Introduce streaming and structured outputs via an optional `StreamingEvaluator` interface.
+- Gradually adopt timeline as the primary transcript, enabling selection, focus, copy, and advanced widgets (progress, tables, diffs, shell panels, inspectors, perf sparklines).
+
+This approach keeps today’s REPL usable while unlocking a clear path to a significantly richer, extensible, and composable user experience.
+

--- a/ttmp/2025-08-31/02-refactoring-repl-to-use-timeline-centric-design.md
+++ b/ttmp/2025-08-31/02-refactoring-repl-to-use-timeline-centric-design.md
@@ -1,0 +1,263 @@
+# Refactoring REPL to a Timeline‑Centric Design (No Backcompat)
+
+This document specifies a detailed architecture, design, and implementation plan to refactor the REPL to a timeline‑first UI. We explicitly do not maintain backward compatibility; the REPL becomes a thin input + controller shell while the timeline renders the complete transcript via entity models.
+
+
+## Goals
+
+- Replace monolithic REPL transcript rendering with append‑only timeline entities.
+- Make structured/streaming output first‑class via a new evaluator contract.
+- Ship a minimal, testable slice first, then progressively add widgets.
+- Keep ergonomics: simple input, history navigation, slash commands, external editor.
+
+
+## High‑Level Architecture
+
+- REPL Model (UI shell)
+  - Owns a `timeline.Controller` and `timeline.Registry`.
+  - Renders two regions:
+    - Timeline viewport (transcript)
+    - Input line (or multiline editor) with status/help
+  - Handles focus switching (timeline selection vs input focus).
+
+- Evaluator (streaming, structured)
+  - New interface that emits typed events (stdout, stderr, markdown result, table, etc.).
+  - REPL bridges events → timeline entity lifecycle.
+
+- Renderers (widgets)
+  - Reuse existing `llm_text`, `tool_calls_panel`, `plain`.
+  - Add REPL‑specific minimal widgets and extend over time.
+
+
+## Package Layout (Target)
+
+- `pkg/repl/` (refactored in place; no backcompat)
+  - `model.go` — New REPL shell model (timeline + input)
+  - `evaluator.go` — New evaluator interfaces (streaming)
+  - `bridge.go` — Maps evaluator events to timeline messages
+  - `messages.go` — REPL messages (unchanged where possible)
+  - `styles.go` — Styles for input/status; entity styles via timeline renderers
+  - `history.go` — Kept, used only for input recall (no transcript rendering)
+- `pkg/timeline/` — Unchanged; register additional factories here or in REPL init
+- `pkg/timeline/renderers/`
+  - `repl_input_model.go` — Minimal input code widget (new)
+  - (later) `repl_stdout_model.go`, `repl_stderr_model.go`, `repl_progress_model.go`, etc.
+- `cmd/repl-timeline-demo/` — Demo program exercising new REPL
+
+
+## New Evaluator Contract
+
+```go
+// pkg/repl/evaluator.go
+
+// EventKind enumerates structured output kinds.
+type EventKind string
+const (
+  EventInput            EventKind = "repl_input"
+  EventResultMarkdown   EventKind = "repl_result_markdown"
+  EventStdout           EventKind = "repl_stdout"
+  EventStderr           EventKind = "repl_stderr"
+  EventToolCalls        EventKind = "repl_tool_calls"
+  EventProgress         EventKind = "repl_progress"
+  EventPerf             EventKind = "repl_perf"
+  EventTable            EventKind = "repl_table"
+  EventDiff             EventKind = "repl_diff"
+  EventShellCmd         EventKind = "repl_shell_cmd"
+  EventInspector        EventKind = "repl_inspector"
+)
+
+// Event carries a semantic payload for the UI.
+type Event struct {
+  Kind  EventKind
+  Props map[string]any // renderer props patch
+}
+
+// Evaluator executes code and streams events.
+type Evaluator interface {
+  EvaluateStream(ctx context.Context, code string, emit func(Event)) error
+  GetPrompt() string
+  GetName() string
+  SupportsMultiline() bool
+  GetFileExtension() string
+}
+```
+
+Notes:
+- We eliminate the old `(string, error)` return. All output is events; errors are represented as events (stderr or result with error state) and the method’s terminal error.
+- The REPL shell remains responsible for creating an input event and for turn ID management.
+
+
+## Timeline Bridge
+
+Responsibilities:
+- Create a new TurnID per submit.
+- Emit `UIEntityCreated` for the input entity.
+- Lazily create stream entities (stdout/stderr) on first chunk; update with patches.
+- Emit result entity/entities and mark completed at the end.
+
+Sketch:
+
+```go
+// pkg/repl/bridge.go
+
+type Bridge struct {
+  ctrl *timeline.Controller
+  reg  *timeline.Registry
+  clock func() time.Time
+}
+
+func (b *Bridge) NewTurnID() string { /* counter or ULID */ }
+
+func (b *Bridge) Emit(turnID, local, kind string, props map[string]any) timeline.EntityID {
+  id := timeline.EntityID{TurnID: turnID, LocalID: local, Kind: kind}
+  b.ctrl.OnCreated(timeline.UIEntityCreated{
+    ID: id,
+    Renderer: timeline.RendererDescriptor{Kind: kind},
+    Props: props,
+    StartedAt: b.clock(),
+  })
+  return id
+}
+
+func (b *Bridge) Patch(id timeline.EntityID, patch map[string]any) { /* OnUpdated */ }
+func (b *Bridge) Complete(id timeline.EntityID, result map[string]any) { /* OnCompleted */ }
+```
+
+Mapping evaluator events → emit/patch/complete:
+- `EventInput` → Emit once at start
+- `EventStdout/Stderr` → Emit on first chunk; Patch thereafter
+- `EventResultMarkdown/Table/Diff/Inspector/ToolCalls` → Emit immediately when available; Complete on finalize
+- `EventProgress/Perf` → Emit once, Patch periodically, optional completion
+
+
+## Minimal Widget Set (MVP)
+
+Focus on smallest viable feature set to test end‑to‑end:
+- `repl_input` (new): boxed monospace view of submitted code; copyable
+- `repl_result_markdown` (reuse `llm_text`): supports markdown, code copy, metadata footer (duration/exit code)
+- Fallback `plain` for anything else during MVP
+
+Later increments:
+- `repl_stdout`, `repl_stderr` (streaming text with distinct styles)
+- `repl_progress` (single‑line progress/spinner)
+- `repl_tool_calls` (extend `tool_calls_panel`)
+- `repl_perf` (sparkline)
+- `repl_table`, `repl_diff`, `repl_shell_cmd`, `repl_inspector`
+
+
+## REPL Shell Model (New)
+
+Composition:
+- Fields: `ctrl *timeline.Controller`, `reg *timeline.Registry`, `input textinput.Model`, `history *History`, `width,height int`, `focus enum{Input, Timeline}`, `bridge Bridge`, `turnSeq int`.
+- Init: register renderers (`llm_text`, `tool_calls_panel`, `plain`, `repl_input`).
+- Update:
+  - `tea.WindowSizeMsg`: compute layout; `ctrl.SetSize(w, timelineHeight)` and adjust input width.
+  - `tea.KeyMsg`:
+    - Focus switching: `tab` toggles between Input and Timeline
+    - When focus=Timeline: up/down move selection; enter toggles entering mode; `c/y` copy code/text
+    - When focus=Input: up/down navigate history; enter submits
+  - Submit flow:
+    - Build `turnID := fmt.Sprintf("turn-%d", m.turnSeq++)`
+    - Bridge emit input entity (`repl_input`) with prompt+code
+    - Start evaluator goroutine; map events → bridge calls; on completion, emit result entity and complete
+- View:
+  - Header/title line
+  - Timeline viewport (controller.View()) above
+  - Input line and help/status below
+
+
+## Keybindings (Initial)
+
+- Global: `q`/`ctrl+c` quit
+- Focus: `tab` toggle Input <-> Timeline, `esc` exit timeline entering mode
+- Input focus:
+  - `enter` submit; `ctrl+e` external editor; `up/down` history; `ctrl+j` add multiline line
+- Timeline focus:
+  - `up/down` selection; `enter` toggle entering; `c` copy code; `y` copy text
+
+
+## Theming
+
+- Maintain REPL input/status theming in `pkg/repl/styles.go`.
+- Timeline entity theming via each renderer; allow `Controller.SetTheme("dark"|"light"|customKey)` to broadcast.
+- Provide a mapping function from REPL theme → renderer props for consistency.
+
+
+## Implementation Plan
+
+Phase 0 — Preparation
+- Create `cmd/repl-timeline-demo` skeleton app.
+- Add basic logging (no external deps beyond zerolog if already in repo).
+
+Phase 1 — New Evaluator + Bridge + Shell MVP
+- Replace `pkg/repl/evaluator.go` with the new `Evaluator` interface and `Event`/`EventKind`.
+- Add `pkg/repl/bridge.go` implementing timeline emission helpers.
+- Refactor `pkg/repl/model.go`:
+  - Remove transcript rendering; keep input/history/editor logic.
+  - Add timeline controller + registry; register `llm_text`, `tool_calls_panel`, `plain`.
+  - Add focus management and key routing to controller (`SelectNext/Prev`, `EnterSelection/ExitSelection`, `SendToSelected`).
+  - On submit: create `turnID`, emit `repl_input`, run `EvaluateStream` and map events. For MVP, map final string‑like outcome to `EventResultMarkdown` (e.g., the evaluator can simply emit that event once).
+- Add `pkg/timeline/renderers/repl_input_model.go` (minimal):
+  - Props: `prompt`, `code`, `language?`, `cwd?`, optional `timestamp`
+  - View: boxed code; implement `EntityCopyTextMsg` to copy `code`.
+
+Phase 2 — Examples and Demo
+- Add `cmd/repl-timeline-demo/main.go` creating a simple evaluator that emits just `EventResultMarkdown`.
+- Update `examples/repl/*` to use the new REPL; remove examples using the old `(string,error)` API.
+
+Phase 3 — Streaming + stdout/stderr
+- Implement `repl_stdout_model.go` and `repl_stderr_model.go` with stream support (append text; handle width changes).
+- Add a `ShellEvaluator` that emits `EventStdout`/`EventStderr` in real time and a final `EventResultMarkdown` with exit code/duration.
+
+Phase 4 — Progressive Widgets
+- Add `repl_progress` and integrate with long‑running evaluators.
+- Extend `repl_tool_calls` with `tool_calls_panel` to mirror sub‑steps.
+- Add `repl_perf` (sparkline) to visualize last N eval durations.
+- Add `repl_table`, `repl_diff`, `repl_shell_cmd`, `repl_inspector` based on usage.
+
+Phase 5 — Polishing and API Stabilization
+- Theme propagation across timeline and input.
+- Copy semantics and UX docs (key cheatsheet in footer).
+- Benchmarks for large transcripts (thousands of entities).
+
+
+## File‑Level Changes (Initial Commit Scope)
+
+- Modify: `pkg/repl/evaluator.go` — new interfaces and types
+- Modify: `pkg/repl/model.go` — new shell with timeline integration
+- Add: `pkg/repl/bridge.go` — timeline bridge
+- Add: `pkg/timeline/renderers/repl_input_model.go` — minimal renderer
+- Modify: `pkg/repl/messages.go` — keep as is where possible; add any needed messages
+- Keep: `pkg/repl/history.go`, `pkg/repl/styles.go` — used for input only
+- Add: `cmd/repl-timeline-demo/main.go` — boot REPL shell and run
+
+
+## Testing Strategy
+
+- Manual demo: run `go run ./cmd/repl-timeline-demo`.
+- Simulated evaluator: emit a fixed sequence of events (input → result_markdown) to validate entity creation, selection, copy, and resizing.
+- Unit tests for bridge mapping (props patches, completion) and `repl_input_model` copy behavior.
+
+
+## Risks and Mitigations
+
+- Scope creep: enforce MVP (input + result markdown) before stdout/stderr.
+- Event spam: coalesce frequent patches (batch stdout lines) to reduce churn.
+- Width handling: always update models with `EntitySetSizeMsg`; renderers must wrap.
+- API churn: document new evaluator contract and pin examples; no backcompat expected.
+
+
+## Acceptance Criteria (MVP)
+
+- Submitting input produces two entities: `repl_input` and `repl_result_markdown`.
+- Timeline renders above input; selection and copy work (c/y).
+- Window resize updates both timeline and input widths.
+- Example evaluator emits result markdown and demo runs without panics.
+
+
+## Follow‑ups
+
+- Implement stdout/stderr and progress widgets.
+- Theme harmonization across timeline renderers.
+- Add navigable “turns” sidebar or filters (via labels) if needed.
+

--- a/ttmp/2025-09-01/01-using-watermill-for-a-timeline-based-repl-design.md
+++ b/ttmp/2025-09-01/01-using-watermill-for-a-timeline-based-repl-design.md
@@ -1,0 +1,245 @@
+# Using Watermill for a Timeline‑Based REPL Design
+
+This document analyzes Pinocchio’s simple‑chat‑agent (including its UI and backend), then proposes a Watermill‑based architecture for Bobatea’s REPL/timeline. The current channel‑heavy coupling in the REPL becomes difficult to reason about and scale; moving to a router/pub‑sub topology (Watermill) simplifies orchestration, decouples concerns, and provides a path to distributed operation (in‑memory or Redis Streams).
+
+
+## 1) Reference: Pinocchio simple‑chat‑agent
+
+Files reviewed:
+- `pinocchio/cmd/agents/simple-chat-agent/main.go`
+- `pinocchio/cmd/agents/simple-chat-agent/pkg/backend/tool_loop_backend.go`
+- `pinocchio/cmd/agents/simple-chat-agent/pkg/ui/*`
+- `pinocchio/pkg/redisstream/*`
+
+### 1.1 Router + Sink + Topics
+- Builds an `events.EventRouter` via `rediscfg.BuildRouter(settings, verbose)` that supports:
+  - In‑memory (Watermill) when Redis disabled
+  - Redis Streams publisher/subscriber when enabled (with group isolation support)
+- Topics logically separated:
+  - `chat` — engine/middleware/tool events
+  - `ui` — UI forwarding (from router to Bubble Tea program)
+  - `logs` — logging/persistence subscribers
+- `middleware.NewWatermillSink(router.Publisher, "chat")` provides an event sink for engine and middlewares.
+
+### 1.2 Backend: Event → Timeline Forwarder
+- `ToolLoopBackend.MakeUIForwarder(p *tea.Program)` returns a Watermill handler that:
+  - Parses Geppetto events (`EventPartialCompletion*`, `EventFinal`, `EventTool*`, `EventError`, …)
+  - Translates to `timeline.UIEntity{Created,Updated,Completed}` and calls `p.Send(...)`
+  - Emits dedicated renderers: `llm_text`, `tool_call`, `tool_call_result`, `log_event`, `agent_mode`
+  - Uses stable local IDs and per‑event metadata to keep updates idempotent
+- Backend runs the tool loop (`RunToolCallingLoop`) and sets `BackendFinishedMsg` when done; forwarder does not prematurely finish the backend.
+
+### 1.3 UI Layer
+- `pkg/ui/app.go` composes:
+  - A REPL component for input/history
+  - A viewport to show transcript (or an overlay for interactive forms)
+  - A sidebar for mode/tool diagnostics, toggled at runtime
+- Integration patterns:
+  - Channel forwarder example: `xevents.AddUIForwarder(router, uiCh)` pushes events to a channel the model reads. This is optional — the primary path uses the backend forwarder to send timeline messages directly to `tea.Program`.
+  - Tool forms integration via overlay model (generative UI pattern). Forms are fed via channel; replies return over channels.
+- Logging/persistence handlers subscribe to `chat` and write to SQLite (and stdout pretty‑print if enabled).
+
+### 1.4 Redis Streams Utilities
+- `rediscfg.BuildRouter` returns a router with Redis publisher/subscriber or in‑memory fallback.
+- `BuildGroupSubscriber` and `EnsureGroupAtTail` let you isolate handlers (e.g., UI vs logs) and avoid full backlog replay.
+
+
+## 2) Why Watermill for Bobatea REPL
+
+Problems with channel‑heavy approach:
+- Tight coupling: producers and consumers depend on each other’s concrete channels and lifetimes.
+- Scaling pain: when adding more features (copy/paste, structured output, tables, progress bars, file ops, logs, persistence), it’s hard to route and fan‑out safely.
+- Backpressure and ordering: manual channel management risks deadlocks or dropped events without visibility.
+
+Watermill advantages:
+- Decoupling via topics: produce once, subscribe many (UI, logs, persistence, test injectors).
+- Swappable transport: in‑memory by default; Redis Streams for durability and multi‑process.
+- Handler composition: add or remove subscribers (UI forwarder, logger, metrics, recorder) with no code changes in producers.
+- Isolation: consumer groups to isolate UI vs logging; replay control with `EnsureGroupAtTail`.
+
+
+## 3) Proposed Bobatea Architecture (REPL + Timeline)
+
+### 3.1 Topics and Message Contracts
+- Topics:
+  - `ui.entities` — carries timeline lifecycle messages:
+    - `UIEntityCreated{ID, Renderer, Props, StartedAt}`
+    - `UIEntityUpdated{ID, Patch, Version, UpdatedAt}`
+    - `UIEntityCompleted{ID, Result}`
+    - `UIEntityDeleted{ID}`
+  - `ui.logs` — optional log/info events (tool logs, info panels)
+  - `repl.events` — optional structured REPL events (stdout/stderr/progress) if you keep a semantic layer above timeline
+- ID conventions:
+  - `EntityID{RunID, TurnID, LocalID, Kind}` — use Turn‑scoped LocalIDs and stable Kind for idempotence.
+  - Version monotonicity for `Updated` to allow de‑dupe.
+
+Encoding:
+- JSON payloads with a `type` field, e.g.:
+  - `{ "type": "timeline.created", ... }`
+  - `{ "type": "timeline.updated", ... }`
+
+### 3.2 REPL → Router → Timeline
+- REPL submits code; an adapter publishes events:
+  - Option A (direct): publish timeline lifecycle messages to `ui.entities` — entity renderers handle display.
+  - Option B (semantic): publish `repl.events` (stdout/stderr/result/progress) and run a transformer subscriber to map them to `ui.entities`.
+- UI subscriber:
+  - In‑process `tea.Program` handler that reads `ui.entities` and `p.Send(...)` timeline messages (akin to Pinocchio’s `MakeUIForwarder`).
+  - Alternatively, a channel forwarder that the REPL model consumes and translates to timeline calls.
+
+### 3.3 Transport and Router
+- Build router with in‑memory transport by default:
+  - `events.NewEventRouter(WithVerbose(...))`
+- Optional Redis Streams:
+  - `rediscfg.BuildRouter(settings, verbose)` and `BuildGroupSubscriber()` for multiple independent subscribers.
+- Subscribers:
+  - `ui-forward` (program forwarder) on `ui.entities`
+  - `event-logger` on `ui.entities` and/or `repl.events`
+  - `event-persist` on `ui.entities` (e.g., SQLite transcripts)
+
+### 3.4 Entity Renderers and Timeline Controller
+- Reuse Bobatea’s timeline renderers (`text`, `markdown`, `structured_data`, etc.).
+- Keep the REPL transcript as a timeline Shell (viewport) so that UI remains responsive.
+- Ensure properties:
+  - Coalesce frequent updates (stdout/stderr) at the publisher or transformer level to reduce UI churn.
+  - Stable IDs and versions for idempotent updates.
+
+
+## 4) Detailed Wiring (Pseudo‑code)
+
+### 4.1 Setup
+```go
+// Build router (memory or Redis based on config)
+router, err := buildRouterFromConfig(cfg)
+uiTopic := "ui.entities"
+
+// Program + UI forwarder
+p := tea.NewProgram(appModel)
+router.AddHandler("ui-forward", uiTopic, makeUIForwarder(p))
+
+// Optional: logs and persistence
+router.AddHandler("ui-logger", uiTopic, logHandler)
+router.AddHandler("ui-persist", uiTopic, persistHandler)
+
+// Start router and UI
+ctx, cancel := context.WithCancel(context.Background())
+eg, ctx := errgroup.WithContext(ctx)
+eg.Go(func() error { return router.Run(ctx) })
+eg.Go(func() error { _, err := p.Run(); cancel(); return err })
+if err := eg.Wait(); err != nil { log.Error().Err(err).Msg("exit") }
+```
+
+### 4.2 REPL Publisher (Direct timeline messages)
+```go
+func publishTimelineCreated(pub message.Publisher, e timeline.UIEntityCreated) error {
+    b, _ := json.Marshal(struct{ Type string; timeline.UIEntityCreated }{"timeline.created", e})
+    return pub.Publish("ui.entities", message.NewMessage(watermill.NewUUID(), b))
+}
+```
+
+### 4.3 UI Forwarder (Program handler)
+```go
+func makeUIForwarder(p *tea.Program) func(msg *message.Message) error {
+    return func(msg *message.Message) error {
+        defer msg.Ack()
+        var env struct{ Type string; Payload json.RawMessage }
+        if err := json.Unmarshal(msg.Payload, &env); err != nil { return err }
+        switch env.Type {
+        case "timeline.created":
+            var e timeline.UIEntityCreated; _ = json.Unmarshal(env.Payload, &e)
+            p.Send(e)
+        case "timeline.updated":
+            var e timeline.UIEntityUpdated; _ = json.Unmarshal(env.Payload, &e)
+            p.Send(e)
+        case "timeline.completed":
+            var e timeline.UIEntityCompleted; _ = json.Unmarshal(env.Payload, &e)
+            p.Send(e)
+        case "timeline.deleted":
+            var e timeline.UIEntityDeleted; _ = json.Unmarshal(env.Payload, &e)
+            p.Send(e)
+        }
+        return nil
+    }
+}
+```
+
+### 4.4 Transformer (Optional: REPL events → timeline)
+```go
+// Subscribes to repl.events; publishes mapped timeline messages to ui.entities
+router.AddHandler("repl-to-ui", "repl.events", func(msg *message.Message) error {
+    defer msg.Ack()
+    ev := parseReplEvent(msg.Payload)
+    out := mapReplEventToTimeline(ev)
+    return pub.Publish("ui.entities", out...)
+})
+```
+
+
+## 5) Operational Considerations
+
+- Backpressure:
+  - Use buffered topics and coalescing; drop non‑critical updates (e.g., logs) when the UI is saturated.
+  - Watermill provides handler concurrency; keep UI forwarder single‑threaded to preserve ordering.
+- Idempotence:
+  - Stable IDs and monotonic versions for `Updated` messages; subscribers may reprocess after failures.
+- Consumer groups (Redis):
+  - UI, logging, and persistence each with their own group to prevent interference.
+  - Use `EnsureGroupAtTail` for first‑run to avoid replay storms.
+- Error handling:
+  - Always Ack messages; log parse/mapping issues separately.
+- Security/sandboxing:
+  - If evaluators run untrusted code, isolate publishers so UI can’t be blocked by evaluator issues.
+
+
+## 6) Incremental Plan for Bobatea
+
+Phase 1 — Foundations
+- Add a small `pkg/eventbus` wrapper:
+  - Build in‑memory router by default; enable Redis via config.
+  - Provide `Publisher()` and helpers for timeline lifecycle messages with `{Type,Payload}` envelopes.
+- Add a `ui-forward` handler to send timeline messages to the Bubble Tea program.
+
+Phase 2 — REPL Integration
+- Replace channel coupling with a REPL publisher:
+  - Directly publish `UIEntity{Created,Updated,Completed,Deleted}` to `ui.entities` during evaluation.
+  - Or publish `repl.events` and include a transformer subscriber.
+- Keep the timeline Shell as the transcript viewport. Ensure refresh is debounced and coalesced for heavy output.
+
+Phase 3 — Observability
+- Add `ui-logger` and `ui-persist` handlers.
+- Optional: pretty console sink (like pinocchio’s `xevents.AddPrettyHandlers`) for CLI debugging.
+
+Phase 4 — Redis Streams (Optional)
+- Wire `rediscfg.BuildRouter` and per‑handler `BuildGroupSubscriber`.
+- Use `EnsureGroupAtTail` for `ui.entities` and `repl.events` streams.
+
+
+## 7) Mapping Examples
+
+- stdout chunk → `timeline.updated{ id: {turn, local: "stdout", kind: "text"}, patch: {append: "..."}}`
+- stderr → same as stdout with `is_error: true`
+- final result markdown → `timeline.created{ id: {local:"result-<n>", kind:"markdown"}, props:{markdown:"..."}}` followed by `timeline.completed`.
+- structured JSON result → `structured_data` renderer with `data` or `json` prop.
+
+
+## 8) Why this fixes our scaling issues
+
+- Replaces bespoke channels with explicit topics; adding features is additive (new handlers).
+- Decouples evaluator lifecycles from UI rendering; retry and replay semantics defined by the router.
+- Makes multi‑process distribution straightforward: evaluators can run elsewhere, UI stays local.
+- Preserves rich timeline rendering with minimal changes to the REPL core.
+
+
+## 9) Action Items
+
+- Implement `pkg/eventbus` with Watermill router setup (memory + Redis).
+- Implement `pkg/ui/forwarder` for `ui.entities` → `tea.Program.Send(...)` (mirroring Pinocchio’s backend forwarder).
+- Update the REPL to publish timeline messages instead of calling controller directly.
+- Add a demo wiring (like `cmd/repl-timeline-bus-demo`) showing:
+  - REPL input → publishes events
+  - UI forwarder → applies to timeline
+  - Optional logger/persist subscribers
+
+---
+
+Pinocchio’s simple‑chat‑agent demonstrates a clean, scalable pattern: engines + middlewares publish to a router; specialized handlers forward to the timeline UI, log, and persist — all without entangling components. Adopting Watermill for Bobatea’s REPL will simplify our architecture, improve resilience, and make advanced features (tools, inspectors, progress, logs) easier to integrate and maintain.
+


### PR DESCRIPTION
- Refactor the REPL to adopt a timeline-first architecture.
- Introduce a new `Evaluator` interface for structured and streaming outputs.
- Implement a `Bridge` to map evaluator events to timeline lifecycle messages.
- Create new renderers for timeline entities: `repl_input`, `repl_stdout`, 
  `repl_stderr`, and `repl_result_markdown`.
- Update the REPL model to handle input and timeline rendering.
- Enhance logging and event handling via Watermill for pub-sub functionality.
- Implement an in-memory event bus for communication between components.