### PR TITLE
Remove excessive per-token streaming debug logging

### DIFF
--- a/pkg/chat/model.go
+++ b/pkg/chat/model.go
@@ -355,13 +355,6 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	// Consolidated logger for this update call
 	logger := log.With().Int64("update_call_id", updateCallID).Logger()
-	logger.Trace().
-		Str("msg_type", msgType).
-		Str("current_state", string(m.state)).
-		Bool("scroll_to_bottom", m.scrollToBottom).
-		Bool("backend_finished", m.backend.IsFinished()).
-		Time("start_time", updateStartTime).
-		Msg("UPDATE ENTRY")
 
 	var cmds []tea.Cmd
 	var cmd tea.Cmd
@@ -471,28 +464,24 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 		// Accept external timeline lifecycle messages (e.g., from backend simulating agent tool calls)
 	case timeline.UIEntityCreated:
-		logger.Debug().Str("lifecycle", "created").Str("kind", msg_.ID.Kind).Str("local_id", msg_.ID.LocalID).Msg("Applying external entity event")
 		m.timelineSh.OnCreated(msg_)
 		if m.scrollToBottom {
 			m.timelineSh.GotoBottom()
 		}
 		return m, nil
 	case timeline.UIEntityUpdated:
-		logger.Debug().Str("lifecycle", "updated").Str("kind", msg_.ID.Kind).Str("local_id", msg_.ID.LocalID).Int64("version", msg_.Version).Msg("Applying external entity event")
 		m.timelineSh.OnUpdated(msg_)
 		if m.scrollToBottom {
 			m.timelineSh.GotoBottom()
 		}
 		return m, nil
 	case timeline.UIEntityCompleted:
-		logger.Debug().Str("lifecycle", "completed").Str("kind", msg_.ID.Kind).Str("local_id", msg_.ID.LocalID).Msg("Applying external entity event")
 		m.timelineSh.OnCompleted(msg_)
 		if m.scrollToBottom {
 			m.timelineSh.GotoBottom()
 		}
 		return m, nil
 	case timeline.UIEntityDeleted:
-		logger.Debug().Str("lifecycle", "deleted").Str("kind", msg_.ID.Kind).Str("local_id", msg_.ID.LocalID).Msg("Applying external entity event")
 		m.timelineSh.OnDeleted(msg_)
 		if m.scrollToBottom {
 			m.timelineSh.GotoBottom()
@@ -747,30 +736,17 @@ func (m *model) startBackend() tea.Cmd {
 	m.textArea.Blur()
 	m.updateKeyBindings()
 
-	log.Debug().
-		Int64("start_call_id", startCallID).
-		Msg("Calling viewport.GotoBottom()")
 	m.timelineSh.GotoBottom()
 
 	refreshCmd := func() tea.Msg {
-		log.Debug().
-			Int64("start_call_id", startCallID).
-			Msg("REFRESH MESSAGE FROM START BACKEND - LOOP RISK")
 		return refreshMessageMsg{
 			GoToBottom: true,
 		}
 	}
 
 	backendCmd := func() tea.Msg {
-		log.Debug().
-			Int64("start_call_id", startCallID).
-			Msg("BACKEND START COMMAND EXECUTING (no-op in new prompt flow)")
 		return nil
 	}
-
-	log.Debug().
-		Int64("start_call_id", startCallID).
-		Msg("START BACKEND EXIT - returning batch of refresh + backend commands")
 
 	return tea.Batch(refreshCmd, backendCmd)
 }
@@ -778,10 +754,6 @@ func (m *model) startBackend() tea.Cmd {
 func (m *model) submit() tea.Cmd {
 	submitCallID := atomic.AddInt64(&updateCallCounter, 1)
 	slogger := log.With().Int64("submit_call_id", submitCallID).Logger()
-	slogger.Trace().
-		Bool("backend_finished", m.backend.IsFinished()).
-		Int("input_length", len(m.textArea.Value())).
-		Msg("SUBMIT ENTRY")
 
 	// Filter out empty submissions (spaces/newlines only)
 	rawInput := m.textArea.Value()
@@ -821,23 +793,18 @@ func (m *model) submit() tea.Cmd {
 
 	// Add entity to timeline
 	id := uuid.New().String()
-	log.Debug().Str("component", "chat").Str("when", "submit").Str("id", id).Msg("Adding user message to timeline")
 	m.timelineSh.OnCreated(timeline.UIEntityCreated{
 		ID:       timeline.EntityID{LocalID: id, Kind: "llm_text"},
 		Renderer: timeline.RendererDescriptor{Kind: "llm_text"},
 		Props:    map[string]any{"role": "user", "text": userMessage},
 	})
 	m.timelineSh.OnCompleted(timeline.UIEntityCompleted{ID: timeline.EntityID{LocalID: id, Kind: "llm_text"}})
-	log.Debug().Str("component", "chat").Str("when", "submit").Str("id", id).Msg("User message added to timeline")
 
 	if !m.externalInput {
 		m.textArea.SetValue("")
 	}
 
 	refreshCmd := func() tea.Msg {
-		log.Debug().
-			Int64("submit_call_id", submitCallID).
-			Msg("REFRESH COMMAND EXECUTED - POTENTIAL LOOP TRIGGER")
 		return refreshMessageMsg{GoToBottom: true}
 	}
 

--- a/pkg/timeline/controller.go
+++ b/pkg/timeline/controller.go
@@ -92,7 +92,6 @@ func (c *Controller) OnCreated(e UIEntityCreated) {
 
 func (c *Controller) OnUpdated(e UIEntityUpdated) {
 	if rec, ok := c.store.get(e.ID); ok {
-		log.Debug().Str("component", "timeline_controller").Str("event", "updated").Str("kind", e.ID.Kind).Str("local_id", e.ID.LocalID).Int64("version", e.Version).Int("patch_len", len(e.Patch)).Msg("applying update")
 		applyPatch(rec.Props, e.Patch)
 		if rec.model != nil {
 			rec.model.Update(EntityPropsUpdatedMsg{ID: rec.ID, Patch: e.Patch})
@@ -104,7 +103,6 @@ func (c *Controller) OnUpdated(e UIEntityUpdated) {
 
 func (c *Controller) OnCompleted(e UIEntityCompleted) {
 	if rec, ok := c.store.get(e.ID); ok {
-		log.Debug().Str("component", "timeline_controller").Str("event", "completed").Str("kind", e.ID.Kind).Str("local_id", e.ID.LocalID).Int("result_len", len(e.Result)).Msg("applying complete")
 		if len(e.Result) > 0 {
 			applyPatch(rec.Props, e.Result)
 		}
@@ -116,7 +114,6 @@ func (c *Controller) OnCompleted(e UIEntityCompleted) {
 }
 
 func (c *Controller) OnDeleted(e UIEntityDeleted) {
-	log.Debug().Str("component", "timeline_controller").Str("event", "deleted").Str("kind", e.ID.Kind).Str("local_id", e.ID.LocalID).Msg("applying delete")
 	c.store.remove(e.ID)
 	if c.selected >= len(c.store.order) {
 		c.selected = len(c.store.order) - 1

--- a/pkg/timeline/shell.go
+++ b/pkg/timeline/shell.go
@@ -68,14 +68,11 @@ func (s *Shell) UpdateViewport(msg tea.Msg) tea.Cmd {
 
 // RefreshView regenerates the viewport content and optionally scrolls to bottom.
 func (s *Shell) RefreshView(goToBottom bool) {
-	start := time.Now()
 	v := s.ctrl.View()
 	s.viewport.SetContent(v)
 	if goToBottom || s.scrollToBottom {
 		s.viewport.GotoBottom()
 	}
-	dur := time.Since(start)
-	log.Debug().Str("component", "timeline_shell").Str("op", "RefreshView").Dur("dur", dur).Int("len", len(v)).Msg("refreshed viewport content")
 }
 
 // GotoBottom forces the viewport to scroll to the bottom.


### PR DESCRIPTION
## Summary
- Remove per-token debug logs from timeline shell `RefreshView`, controller `OnUpdated`/`OnCompleted`/`OnDeleted`, and chat model entity lifecycle events
- Remove `START BACKEND` diagnostic logs and `SUBMIT ENTRY` trace logs
- ~39 lines removed across 3 files

These logs fired hundreds of times per completion with no actionable value.

## Test plan
- [x] All tests pass (`go test ./...`)
- [x] Lint clean (`golangci-lint`)
- [x] Security scan clean (`gosec`, `govulncheck`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)